### PR TITLE
team.md miscellaneous changes

### DIFF
--- a/organization/team.md
+++ b/organization/team.md
@@ -16,7 +16,7 @@ Currently the activities within the HSF are organized by the *HSF startup team*.
  * Pere Mato [CERN](http://cern.ch), co-lead
  * Dario Menasce [INFN](http://www.mi.infn.it)
  * Elizabeth Sexton-Kennedy [FNAL](http://www.fnal.gov)
- * Graeme Steward [Glasgow](http://www.gla.ac.uk/schools/physics/research/groups/particlephysicsexperiment/)
+ * Graeme Stewart [Glasgow](http://www.gla.ac.uk/schools/physics/research/groups/particlephysicsexperiment/)
  * Craig Tull [LBNL](http://www.lbl.gov)
  * Andrea Valassi [CERN](http://cern.ch)
  * Brett Viren [BNL](https://www.bnl.gov)

--- a/organization/team.md
+++ b/organization/team.md
@@ -7,22 +7,22 @@ layout: default
 
 Currently the activities within the HSF are organized by the *HSF startup team*. Following the concept of a do-ocracy active contributors to the HSF are invited to join. These are the current members of the startup team:
 
- * [Amber Boehnlein](amber@slac.stanford.edu) (SLAC)
- * [Peter Elmer](peter.elmer@cern.ch) (Princeton)
- * [Daniel Elvira](daniel@fnal.gov) (FNAL)
- * [Frank Gaede](frank.gaede@desy.de) (DESY)
- * [Benedikt Hegner](benedikt.hegner@cern.ch) (CERN)
- * [Michel Jouvin](jouvin@lal.in2p3.fr) (LAL,IN2P3)
- * [Pere Mato](pere.Mato@cern.ch) (CERN, co-lead)
- * [Dario Menasce](dario.menasce@mib.infn.it) (INFN)
- * [Elizabeth Sexton-Kennedy](sexton@fnal.gov) (FNAL)
- * [Graeme Steward](graeme.a.steward@gmail.com) (Glasgow)
- * [Craig Tull](cetull@lbl.gov) (LBNL)
- * [Andrea Valassi](andrea.valassi@cern.ch) (CERN)
- * [Brett Viren](bv@bnl.gov) (BNL)
- * [Torre Wenaus](wenaus@gmail.com) (BNL, co-lead)
+ * Amber Boehnlein [SLAC](https://www6.slac.stanford.edu)
+ * Peter Elmer [Princeton](https://www.princeton.edu/physics/)
+ * Daniel Elvira [FNAL](http://www.fnal.gov)
+ * Frank Gaede [DESY](http://www.desy.de)
+ * Benedikt Hegner [CERN](http://cern.ch)
+ * Michel Jouvin [LAL,IN2P3](http://www.lal.in2p3.fr)
+ * Pere Mato [CERN](http://cern.ch), co-lead
+ * Dario Menasce [INFN](http://www.mi.infn.it)
+ * Elizabeth Sexton-Kennedy [FNAL](http://www.fnal.gov)
+ * Graeme Steward [Glasgow](http://www.gla.ac.uk/schools/physics/research/groups/particlephysicsexperiment/)
+ * Craig Tull [LBNL](http://www.lbl.gov)
+ * Andrea Valassi [CERN](http://cern.ch)
+ * Brett Viren [BNL](https://www.bnl.gov)
+ * Torre Wenaus [BNL](https://www.bnl.gov), co-lead
 
-The entire team can be contacted via [hep-sf-startup-team@googlegroups.com](hep-sf-startup-team@googlegroups.com).
+The entire team can be contacted via <hep-sf-startup-team@googlegroups.com>.
 
 ## Meeting Minutes
 

--- a/organization/team.md
+++ b/organization/team.md
@@ -37,6 +37,6 @@ The startup team meets regularly. The minutes of these meetings are public:
 ## Presentations given by Startup Team Members
 
  * [HSF introduction presented to the intensity frontier community, Jan 8 2015](/assets/HSF-intro-intensity-20150108.pdf)
- * [Workshop summary presented to the LCG Grid Deployment Board, Michel Jouvin](/assets/HSF-SLAC-workshop-summary-GDB-Feb.pdf)
+ * [Workshop summary presented to the WLCG GDB, Michel Jouvin](/assets/HSF-SLAC-workshop-summary-GDB-Feb.pdf)
  * [Workshop summary presented to ATLAS S&C Week, Vakho Tsulaia](/assets/HSF-Summary-Vakho-Tsulaia-ATLAS.pdf)
  * [Workshop summary presented to CERN PH-SFT, Benedikt Hegner](/assets/Benedikt%20Hegner%20HSFSummary.pdf)


### PR DESCRIPTION
*  fix reference to WLCG GDB (we tend to avoid `Grid Deployment Board` as it doesn't mean anything today)

`team.md` also contains the email of each startup team member as a link: very helpful for spammers! What about removing the link and adding the email as part of the text with the usual `AT.SPAM.NOT` or equivalent? Waiting for feedback before merging this PR...

