### PR TITLE
Newsletter about Technical Notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 .jekyll-metadata
 _site
 Gemfile.lock
+
+# Eclipse
+.project
+
+# PyCharm
+.idea/
+

--- a/newsletter/_posts/2016-03-03-LICTN.md
+++ b/newsletter/_posts/2016-03-03-LICTN.md
@@ -1,0 +1,43 @@
+---
+title: Sharing ideas and code
+author: Benedikt Hegner and Michel Jouvin
+layout: newsletter
+---
+
+One of the aims of the HSF is to give you and your project a forum for exchange. 
+For sharing ideas we set up the *HSF Technical Notes*. 
+And to help you sharing your software with others we had a closer look at possible 
+open source licenses.
+
+## HSF technical notes
+
+[HSF technical notes](http://hepsoftwarefoundation.org/technical_notes.html), 
+or TN in short, are a possibility to share ideas, concepts, or results of discussions.
+
+They are not formal recommendations. They are meant to be informal and inclusive. And can contain any topic you may find relevant
+for the HSF community. The very first HSF TN explains this in detail: 
+[HSF Technical Notes policy](https://github.com/HEP-SF/documents/raw/master/HSF-TN/2015-01/HSF-TN-2015-01.pdf).
+
+Feel free to contribute on your preferred topic! And stay tuned for coming Technical Notes!
+
+## Open Source Licenses
+
+One of the complex questions when developing software is what license should I use for my software?
+Too many projects postpone this question to a later stage: unfortunately changing a license afterwards can
+be difficult.
+
+Unfortunately it is not as easy as just saying - "well, it's open source!". 
+There is no unique answer and there are many considerations when choosing a license, in particular:
+
+  * what do you want others do to or not to do with it?
+  * what other software do I want to take advantage of while developing it?
+
+A [Technical Note](https://github.com/HEP-SF/documents/raw/master/HSF-TN/2016-01/HSF-TN-2016-01.pdf) dedicated to licensing presents the different types of open-source licenses and attempt to provide
+some guidelines for projects who want to define or refine their licensing.
+
+We wait for your feedback on this Technical Note!
+
+## Machine/Job Features
+
+This [Technical Note](https://github.com/HEP-SF/documents/raw/master/HSF-TN/2016-02/HSF-TN-2016-02.pdf) describes a mechanism developed in WLCG allowing a user payload to obtain information about its environment, like number of cores allocated, the CPU power of each core, the remaining time for the job... This mechanism, currently being deployed in WLCG, may be of wider interest.
+


### PR DESCRIPTION
@HEP-SF/startup the proposed technical note about Technical Notes, covering the licensing one and the machine/job features one.