### PR TITLE
May 19 startup meeting notes

### DIFF
--- a/organization/_posts/2016-05-19-startup.md
+++ b/organization/_posts/2016-05-19-startup.md
@@ -1,3 +1,17 @@
+---
+title: "HSF Weekly Meeting #56, May 19 2016"
+layout: default
+---
+
+# HSF Weekly Meeting #56, May 19 2016
+
+### Contents
+{:.no_toc}
+
+* auto-gen TOC:
+{:toc}
+
+
 #### Present: Andrea Valassi, Ben Morgan, Pere Mato, Benedikt Hegner, Liz Sexton-Kennedy, Michel Jouvin, Pete Elmer, John Harvey, David Lange, Frank Gaede, Markus Schulz
 
 ## News, general matters

--- a/organization/_posts/2016-05-19-startup.md
+++ b/organization/_posts/2016-05-19-startup.md
@@ -1,11 +1,128 @@
----
-title: "HSF Weekly Meeting #56, May 19 2016"
-layout: default
----
+#### Present: Andrea Valassi, Ben Morgan, Pere Mato, Benedikt Hegner, Liz Sexton-Kennedy, Michel Jouvin, Pete Elmer, John Harvey, David Lange, Frank Gaede, Markus Schulz
 
-# HSF Weekly #56 19/05/16
+## News, general matters
 
-[Indico Agenda](https://indico.cern.ch/event/533452/)
+-   Using GoogleDoc to take the notes in a collaborative manner. Michel
+    > suggests to export the GoogleDoc to docx and then convert the docx
+    > to Markdown with pandoc. He will demonstrate it with this meeting
+    > notes!
 
-[Google Notes](https://docs.google.com/document/d/13-83-r6GoCWiE0sNSx6zlsknXymkMWr6WnkocEWBAzY/edit#)
+-   Ben: UK HEP community meeting. One of the topics is ‘software’. Ask
+    > somebody from HFS to give a presentation.
+
+-   Andrea: Following up the StackExchange idea. LHCb has its own
+    > instance (sort of Stack Exchange), ask ROOT,... Room
+    > for discussion.
+
+## Current Topics
+
+### Newsletter for LAL workshop
+
+-   Draft from Michel:
+    > (PR)\[[*https://github.com/HEP-SF/hep-sf.github.io/pull/43/files*](https://github.com/HEP-SF/hep-sf.github.io/pull/43/files)\]
+
+-   Contributions from Benedikt. One controversial issue. It is the
+    > second or the third? John: the first one was at CERN. We need to
+    > just to agree.
+
+-   One pending issue: what is the role of the software technology
+    > forum? Will it cover the performance issues? Software Technology
+    > Forum
+
+-   **By Tomorrow noon we will issue the newsletter**: comment in the
+    > pull request if there is anything you’d like to improve. Or to say
+    > that you read it and that it is fine with you! (avoid emails).
+
+### Workshop live notes
+
+-   Draft with final version of GoogleDoc at
+    > [*https://github.com/HEP-SF/hep-sf.github.io/pull/40/files*](https://github.com/HEP-SF/hep-sf.github.io/pull/40/files)
+
+-   To publish the final notes at the same time as the newsletter.
+    > Several modifications went in the GoogleDoc after emails to
+    > workshop participants (we do not know the author but several
+    > persons told Michel they will review the notes).
+
+-   Remove update rights on the GoogleDocs.
+
+### Presentation for LHCC pre-meeting - 25.05.2016
+
+-   \[Draft by
+    > Benedikt\]([*https://docs.google.com/presentation/d/1E39uVohq3QyECfJFdffkrdkCUqB99ZgQ8ltxa91XEe8/edit?usp=sharing*](https://docs.google.com/presentation/d/1E39uVohq3QyECfJFdffkrdkCUqB99ZgQ8ltxa91XEe8/edit?usp=sharing))
+
+-   The referee pre-meeting next week. Benedikt represents the AA of
+    > WLCG at the meeting. Asked to give an update of HSF and status
+    > of GeantV.
+
+-   John: the reason AA was re-instated on request by the
+    > experiment’s representatives.
+
+-   Pete: this time is fine. What we want for later meetings?
+
+-   John: It is legitimate that we ask how the LHCC committee would like
+    > to follow the HSF activities. A dialog is needed. We need to
+    > discuss to F. Forti. Perhaps a few members of the startup team
+    > should participate to the initial discussions. They may need to
+    > define the scope.
+
+-   Michel supports the idea.
+
+-   John: seeking the endorsement of the new management of CERN is
+    > needed since is new.
+
+-   Pete: engage by the process and roadmap that we have been
+    > discussing (CWP). Bootstrapping this recognition process.
+
+-   Frank: what about the other projects beyond LHC? LHCC should be one
+    > example but not the unique one. Seek endorsement by other bodies
+    > (not too many :-)). And only endorsement: this will allow to
+    > liaise with different bodies without the risk of appearing
+    > dedicated to one set of experiments or a subset of the community.
+
+-   John: we need to have a clear messages before talking to
+    > different bodies.
+
+-   Need to rediscuss this topic in more details in a few weeks after
+    > thinking a little bit more to the details on how to proceed and
+    > may be identifying other bodies that may be relevant to HSF (in
+    > particular computing-related ones).
+
+## Activity updates
+
+### Packaging
+
+-   On going active discussion between Benedikt and Patrick. Very
+    > positive collaboration.
+
+-   Should come up soon with a set of agreed requirements.
+
+### Projects
+
+-   Michel: asking people to register projects. Future
+    > conditions database. …
+
+-   Need to follow up with Michel Sokolov about the projects he
+    > mentioned a the workshop.
+
+### Training
+
+-   We received an offer to place C++ training material on WikiToLearn
+    > from a member of IceCube: they are considering to possibility of
+    > using the W2L platform also for their bootcamp. This is
+    > encouraging news, meaning that we are slowly finding contributors
+    > in the field of our interest. This, besides, gives Riccardo the
+    > opportunity of using them as guinea pigs for the new tools made
+    > available to the contributors.
+
+TN
+
+-   Michel encouraging a colleague who has been the architect and
+    > developer of Auger data transfer infrastructure to summarize and
+    > share his experience and the lessons learnt a as a TN
+
+## AOB
+
+-   Check the writing rights of Startup Team documents after
+    > the meeting.
+
 


### PR DESCRIPTION
@HEP-SF/startup  Converted from [GoogleDoc](https://docs.google.com/document/d/13-83-r6GoCWiE0sNSx6zlsknXymkMWr6WnkocEWBAzY/edit?ts=573db430#heading=h.3gcuo4gao26l) with `pandoc` using the following command:

```bash
 pandoc -t markdown --base-header-level=2 --atx-headers -o organization/_posts/2016-05-19-startup.md googledoc.docx
```

with `googledoc.docx` being the `docx` export of the GoogleDoc done with menu `File->Download as`.

The only manual step done after the `pandoc` conversion has been to insert at the beginning of the file the frontmatter lines, the title and the instructions to build a TOC. This can be basically copied from one meeting to the next one (after updating the meeting number and date). The "magic lines" are:

```
---
title: "HSF Weekly Meeting #56, May 19 2016"
layout: default
---

# HSF Weekly Meeting #56, May 19 2016

### Contents
{:.no_toc}

* auto-gen TOC:
{:toc}

```