### PR TITLE
Meeting #56 (May 19) notes: fix urls + minor corrections

### DIFF
--- a/organization/_posts/2016-05-19-startup.md
+++ b/organization/_posts/2016-05-19-startup.md
@@ -12,7 +12,7 @@ layout: default
 {:toc}
 
 
-#### Present: Andrea Valassi, Ben Morgan, Pere Mato, Benedikt Hegner, Liz Sexton-Kennedy, Michel Jouvin, Pete Elmer, John Harvey, David Lange, Frank Gaede, Markus Schulz
+#### *Present*: Andrea Valassi, Ben Morgan, Pere Mato, Benedikt Hegner, Liz Sexton-Kennedy, Michel Jouvin, Pete Elmer, John Harvey, David Lange, Frank Gaede, Markus Schulz
 
 ## News, general matters
 
@@ -32,16 +32,14 @@ layout: default
 
 ### Newsletter for LAL workshop
 
--   Draft from Michel:
-    > (PR)\[[*https://github.com/HEP-SF/hep-sf.github.io/pull/43/files*](https://github.com/HEP-SF/hep-sf.github.io/pull/43/files)\]
-
--   Contributions from Benedikt. One controversial issue. It is the
-    > second or the third? John: the first one was at CERN. We need to
-    > just to agree.
+-   [*Draft*](https://github.com/HEP-SF/hep-sf.github.io/pull/43/files)
+    > from Michel with contributions from Benedikt. One
+    > “controversial” issue. It is the second or the third? John: the
+    > first one was at CERN. We need to just to agree.
 
 -   One pending issue: what is the role of the software technology
-    > forum? Will it cover the performance issues? Software Technology
-    > Forum
+    > forum? Will it cover the performance issues? Change Software
+    > Technical Evolution Forum into Software Technology Forum
 
 -   **By Tomorrow noon we will issue the newsletter**: comment in the
     > pull request if there is anything you’d like to improve. Or to say
@@ -49,8 +47,10 @@ layout: default
 
 ### Workshop live notes
 
--   Draft with final version of GoogleDoc at
-    > [*https://github.com/HEP-SF/hep-sf.github.io/pull/40/files*](https://github.com/HEP-SF/hep-sf.github.io/pull/40/files)
+-   [*Draft*](https://github.com/HEP-SF/hep-sf.github.io/pull/40/files)
+    > available, produced from final version of the
+    > [*GoogleDoc*](https://docs.google.com/document/d/1plPytOtY2HFjSdF3bE6bXJ_aTBQ-OzfbEUcU62X-_qc/edit#)
+    > (now readonly)
 
 -   To publish the final notes at the same time as the newsletter.
     > Several modifications went in the GoogleDoc after emails to
@@ -61,8 +61,8 @@ layout: default
 
 ### Presentation for LHCC pre-meeting - 25.05.2016
 
--   \[Draft by
-    > Benedikt\]([*https://docs.google.com/presentation/d/1E39uVohq3QyECfJFdffkrdkCUqB99ZgQ8ltxa91XEe8/edit?usp=sharing*](https://docs.google.com/presentation/d/1E39uVohq3QyECfJFdffkrdkCUqB99ZgQ8ltxa91XEe8/edit?usp=sharing))
+-   [*Draft*](https://docs.google.com/presentation/d/1E39uVohq3QyECfJFdffkrdkCUqB99ZgQ8ltxa91XEe8/edit?usp=sharing)
+    > by Benedikt
 
 -   The referee pre-meeting next week. Benedikt represents the AA of
     > WLCG at the meeting. Asked to give an update of HSF and status
@@ -126,7 +126,7 @@ layout: default
     > encouraging news, meaning that we are slowly finding contributors
     > in the field of our interest. This, besides, gives Riccardo the
     > opportunity of using them as guinea pigs for the new tools made
-    > available to the contributors.
+    > available to the contributors to the site.
 
 TN
 


### PR DESCRIPTION
Source GoogleDoc had links with a markdown syntax resulting into an incorrect conversion by `pandoc`. GoogleDoc fixed and notes converted again following the procedure described in #44. 