### PR TITLE
Meeting #56 (May 19) notes: fix incorrect conversion of bullet lists

### DIFF
--- a/organization/_posts/2016-05-19-startup.md
+++ b/organization/_posts/2016-05-19-startup.md
@@ -16,127 +16,78 @@ layout: default
 
 ## News, general matters
 
--   Using GoogleDoc to take the notes in a collaborative manner. Michel
-    > suggests to export the GoogleDoc to docx and then convert the docx
-    > to Markdown with pandoc. He will demonstrate it with this meeting
-    > notes!
+-   Using GoogleDoc to take the notes in a collaborative manner. Michel suggests to export the GoogleDoc to docx and then convert the docx to Markdown with pandoc. He will demonstrate it with this meeting notes!
 
--   Ben: UK HEP community meeting. One of the topics is ‘software’. Ask
-    > somebody from HFS to give a presentation.
+-   Ben: UK HEP community meeting. One of the topics is ‘software’. Ask somebody from HFS to give a presentation.
 
--   Andrea: Following up the StackExchange idea. LHCb has its own
-    > instance (sort of Stack Exchange), ask ROOT,... Room
-    > for discussion.
+-   Andrea: Following up the StackExchange idea. LHCb has its own instance (sort of Stack Exchange), ask ROOT,... Room for discussion.
 
 ## Current Topics
 
 ### Newsletter for LAL workshop
 
--   [*Draft*](https://github.com/HEP-SF/hep-sf.github.io/pull/43/files)
-    > from Michel with contributions from Benedikt. One
-    > “controversial” issue. It is the second or the third? John: the
-    > first one was at CERN. We need to just to agree.
+-   [*Draft*](https://github.com/HEP-SF/hep-sf.github.io/pull/43/files) from Michel with contributions from Benedikt. One “controversial” issue. It is the second or the third? John: the first one was at CERN. We need to just to agree.
 
--   One pending issue: what is the role of the software technology
-    > forum? Will it cover the performance issues? Change Software
-    > Technical Evolution Forum into Software Technology Forum
+-   One pending issue: what is the role of the software technology forum? Will it cover the performance issues? Change Software Technical Evolution Forum into Software Technology Forum
 
--   **By Tomorrow noon we will issue the newsletter**: comment in the
-    > pull request if there is anything you’d like to improve. Or to say
-    > that you read it and that it is fine with you! (avoid emails).
+-   **By Tomorrow noon we will issue the newsletter**: comment in the pull request if there is anything you’d like to improve. Or to say that you read it and that it is fine with you! (avoid emails).
 
 ### Workshop live notes
 
--   [*Draft*](https://github.com/HEP-SF/hep-sf.github.io/pull/40/files)
-    > available, produced from final version of the
-    > [*GoogleDoc*](https://docs.google.com/document/d/1plPytOtY2HFjSdF3bE6bXJ_aTBQ-OzfbEUcU62X-_qc/edit#)
-    > (now readonly)
+-   [*Draft*](https://github.com/HEP-SF/hep-sf.github.io/pull/40/files) available, produced from final version of the [*GoogleDoc*](https://docs.google.com/document/d/1plPytOtY2HFjSdF3bE6bXJ_aTBQ-OzfbEUcU62X-_qc/edit#) (now readonly)
 
--   To publish the final notes at the same time as the newsletter.
-    > Several modifications went in the GoogleDoc after emails to
-    > workshop participants (we do not know the author but several
-    > persons told Michel they will review the notes).
+-   To publish the final notes at the same time as the newsletter. Several modifications went in the GoogleDoc after emails to workshop participants (we do not know the author but several persons told Michel they will review the notes).
 
 -   Remove update rights on the GoogleDocs.
 
 ### Presentation for LHCC pre-meeting - 25.05.2016
 
--   [*Draft*](https://docs.google.com/presentation/d/1E39uVohq3QyECfJFdffkrdkCUqB99ZgQ8ltxa91XEe8/edit?usp=sharing)
-    > by Benedikt
+-   [*Draft*](https://docs.google.com/presentation/d/1E39uVohq3QyECfJFdffkrdkCUqB99ZgQ8ltxa91XEe8/edit?usp=sharing) by Benedikt
 
--   The referee pre-meeting next week. Benedikt represents the AA of
-    > WLCG at the meeting. Asked to give an update of HSF and status
-    > of GeantV.
+-   The referee pre-meeting next week. Benedikt represents the AA of WLCG at the meeting. Asked to give an update of HSF and status of GeantV.
 
--   John: the reason AA was re-instated on request by the
-    > experiment’s representatives.
+-   John: the reason AA was re-instated on request by the experiment’s representatives.
 
 -   Pete: this time is fine. What we want for later meetings?
 
--   John: It is legitimate that we ask how the LHCC committee would like
-    > to follow the HSF activities. A dialog is needed. We need to
-    > discuss to F. Forti. Perhaps a few members of the startup team
-    > should participate to the initial discussions. They may need to
-    > define the scope.
+-   John: It is legitimate that we ask how the LHCC committee would like to follow the HSF activities. A dialog is needed. We need to discuss to F. Forti. Perhaps a few members of the startup team should participate to the initial discussions. They may need to define the scope.
 
 -   Michel supports the idea.
 
--   John: seeking the endorsement of the new management of CERN is
-    > needed since is new.
+-   John: seeking the endorsement of the new management of CERN is needed since is new.
 
--   Pete: engage by the process and roadmap that we have been
-    > discussing (CWP). Bootstrapping this recognition process.
+-   Pete: engage by the process and roadmap that we have been discussing (CWP). Bootstrapping this recognition process.
 
--   Frank: what about the other projects beyond LHC? LHCC should be one
-    > example but not the unique one. Seek endorsement by other bodies
-    > (not too many :-)). And only endorsement: this will allow to
-    > liaise with different bodies without the risk of appearing
-    > dedicated to one set of experiments or a subset of the community.
+-   Frank: what about the other projects beyond LHC? LHCC should be one example but not the unique one. Seek endorsement by other bodies (not too many :-)). And only endorsement: this will allow to liaise with different bodies without the risk of appearing dedicated to one set of experiments or a subset of the community.
 
--   John: we need to have a clear messages before talking to
-    > different bodies.
+-   John: we need to have a clear messages before talking to different bodies.
 
--   Need to rediscuss this topic in more details in a few weeks after
-    > thinking a little bit more to the details on how to proceed and
-    > may be identifying other bodies that may be relevant to HSF (in
-    > particular computing-related ones).
+-   Need to rediscuss this topic in more details in a few weeks after thinking a little bit more to the details on how to proceed and may be identifying other bodies that may be relevant to HSF (in particular computing-related ones).
 
 ## Activity updates
 
 ### Packaging
 
--   On going active discussion between Benedikt and Patrick. Very
-    > positive collaboration.
+-   On going active discussion between Benedikt and Patrick. Very positive collaboration.
 
 -   Should come up soon with a set of agreed requirements.
 
 ### Projects
 
--   Michel: asking people to register projects. Future
-    > conditions database. …
+-   Michel: asking people to register projects. Future conditions database. …
 
--   Need to follow up with Michel Sokolov about the projects he
-    > mentioned a the workshop.
+-   Need to follow up with Michel Sokolov about the projects he mentioned a the workshop.
 
 ### Training
 
--   We received an offer to place C++ training material on WikiToLearn
-    > from a member of IceCube: they are considering to possibility of
-    > using the W2L platform also for their bootcamp. This is
-    > encouraging news, meaning that we are slowly finding contributors
-    > in the field of our interest. This, besides, gives Riccardo the
-    > opportunity of using them as guinea pigs for the new tools made
-    > available to the contributors to the site.
+-   We received an offer to place C++ training material on WikiToLearn from a member of IceCube: they are considering to possibility of using the W2L platform also for their bootcamp. This is encouraging news, meaning that we are slowly finding contributors in the field of our interest. This, besides, gives Riccardo the opportunity of using them as guinea pigs for the new tools made available to the contributors to the site.
 
 TN
 
--   Michel encouraging a colleague who has been the architect and
-    > developer of Auger data transfer infrastructure to summarize and
-    > share his experience and the lessons learnt a as a TN
+-   Michel encouraging a colleague who has been the architect and developer of Auger data transfer infrastructure to summarize and share his experience and the lessons learnt a as a TN
 
 ## AOB
 
--   Check the writing rights of Startup Team documents after
-    > the meeting.
+-   Check the writing rights of Startup Team documents after the meeting.
 
 


### PR DESCRIPTION
Overlooked the problem in the initial PRs (#44 and #45): punished for not doing a proper code review!!

Rerun pandoc from docx export with `-t markdown_github` instead of `-t  markdown` (else bullet lists are messed up when items span several lines).
