### PR TITLE
_includes/events.ext: fix processing of announcement date

### DIFF
--- a/_includes/events.ext
+++ b/_includes/events.ext
@@ -1,14 +1,15 @@
 <hr>
   <h4><a href="{{site.baseurl}}/events.html">Upcoming Events</a></h4>
-  <ol class="list-unstyled">
+  <ul class="lead">
 
-  {% assign pagedate =page.date | date: "%m-%d-%Y"   %}
-  {% for post in site.categories.events %}
-    {% assign startdate = post.startdate | string_to_date | date: "%m-%d-%Y" %}
-    {% if startdate > pagedate %}
-      <li><a href="{{site.baseurl}}{{ post.url }}">{{ post.title }}</a> ( starting on {{ post.startdate | date: "%m-%d-%Y" }} ) </li>
+  {% assign sitedate = site.time | date: "%m-%d-%Y"   %}
+  {% for post in site.categories.announcements %}
+    {% assign stopdate = post.until | string_to_date | date: "%m-%d-%Y" %}
+    {% if stopdate > sitedate %}
+    <li>{{ post.title }} (<a href="{{ post.link }}">more info</a>)
     {% endif %}
   {% endfor %}
-  </ol>
+
+  </ul>
 
 See also <a href='https://hepsoftware.org/?popupmode=Events&popupstate=events'>HEP S&amp;C community events</a>


### PR DESCRIPTION
It  was not updated after implementing the new site layout and changing from 'startdate' to 'until', resulting into inappropriate info at the end of some pages (e.g. newsletters).

@hegner I assign you as you are the more likely person able to judge the change! (tested with one announcement `until` date updated into the future).