### PR TITLE
Main page: display events in chronological order

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -25,7 +25,7 @@ The HSF is now beginning community process to develop a consensus roadmap for HE
 </div>
 <hr>
   {% assign sitedate = site.time | date: "%Y-%m-%d"   %}
-  {% for post in site.categories.announcements %}
+  {% for post in site.categories.announcements reversed %}
     {% assign stopdate = post.until | string_to_date | date: "%Y-%m-%d" %}
     {% if stopdate > sitedate %}
 <div class="row alert alert-warning">


### PR DESCRIPTION
Currently, if several "breaking news" are displayed on the main page, they are in reverse chronological order (the first event to occur being last in the list). This is not very much expected, IMO. With this PR, events are displayed in the order in which they occur.