### PR TITLE
GSoC TMVA proposal: fix mentor emails

### DIFF
--- a/_gsocproposals/proposal_TMVAadditional.md
+++ b/_gsocproposals/proposal_TMVAadditional.md
@@ -17,11 +17,11 @@ Toolkit for Multivariate Analysis (TMVA) is a multi-purpose machine learning too
 Strong C++ skills, good understanding of machine learning algorithms
 
 ## Mentors
- <a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA">Sergei Gleyzer</a>​, 
- <a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA">Lorenzo Moneta</a>​, 
- <a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA">Omar Zapata</a>​, 
- <a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA">Stefan Wunsch</a>​, 
- <a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA">Enrico Guiraud</a><br />
+* [Sergei Gleyzer](mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA) 
+* [Lorenzo Moneta](mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA) 
+* [Omar Zapata](mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA)
+* [Stefan Wunsch](mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA)
+* [Enrico Guiraud](mailto:sft-gsoc-AT-cern-dot-ch?subject=Other%20Machine%20Learning%20Projects%20in%20TMVA)
 
 ## Links
 

--- a/_gsocproposals/proposal_TMVAconvolutional.md
+++ b/_gsocproposals/proposal_TMVAconvolutional.md
@@ -19,7 +19,9 @@ Toolkit for Multivariate Analysis (TMVA) is a multi-purpose machine learning too
 Strong C++ skills, solid knowledge of deep learning, understanding of convolutional networks, familiarity with GPU interfaces a plus
 
 ## Mentors
-<a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Convolutional%20Deep%20Neural%20Networks%20on%20GPUs%20for%20Particle%20Physics">Sergei Gleyzer</a>​ and <a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Convolutional%20Deep%20Neural%20Networks%20on%20GPUs%20for%20Particle%20Physics">Lorenzo Moneta</a>
+
+* [Sergei Gleyzer](mailto:sft-gsoc-AT-cern-dot-ch?subject=Convolutional%20Deep%20Neural%20Networks%20on%20GPUs%20for%20Particle%20Physics)
+* [Lorenzo Moneta](mailto:sft-gsoc-AT-cern-dot-ch?subject=Convolutional%20Deep%20Neural%20Networks%20on%20GPUs%20for%20Particle%20Physics)
 
 ## Links
 

--- a/_gsocproposals/proposal_TMVAregression.md
+++ b/_gsocproposals/proposal_TMVAregression.md
@@ -17,9 +17,10 @@ Toolkit for Multivariate Analysis (TMVA) is a multi-purpose machine learning too
 Strong C++ skills, understanding of machine learning and in particular, its application to function estimation/regression</span></p>
 
 ## Mentors
-<a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Multi-Target%2FObjective%20Regression%20using%20Machine%20Learning%20for%20Particle%20Physics">Sergei Gleyzer</a>​, 
-<a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Multi-Target%2FObjective%20Regression%20using%20Machine%20Learning%20for%20Particle%20Physics">Lorenzo Moneta</a>
-<a href="mailto:sft-gsoc-AT-cern-dot-ch?subject=Multi-Target%2FObjective%20Regression%20using%20Machine%20Learning%20for%20Particle%20Physics">Omar Zapata</a>
+
+* [Sergei Gleyzer](mailto:sft-gsoc-AT-cern-dot-ch?subject=Multi-Target%2FObjective%20Regression%20using%20Machine%20Learning%20for%20Particle%20Physics)
+* [Lorenzo Moneta](mailto:sft-gsoc-AT-cern-dot-ch?subject=Multi-Target%2FObjective%20Regression%20using%20Machine%20Learning%20for%20Particle%20Physics)
+* [Omar Zapata](mailto:sft-gsoc-AT-cern-dot-ch?subject=Multi-Target%2FObjective%20Regression%20using%20Machine%20Learning%20for%20Particle%20Physics)
 
 # Links
 


### PR DESCRIPTION
TMVA-related GSoC proposals list a few mentors with their emails. This has two problems:
* [ ] A major one: the pages don't validate (see #76) because the email is invalid. To avoid spamming the address has been written `AT.NOT.SPAM.` and is then invalid. I think we need to produce valid pages (that can be checked successfully with a validator like `htmlproofer`) and I suggest to either put the real emails or to write the email as it is now but not declare it as a `mailto` (but you will look the automatic filling of the subject). I have not done anything else to fix this, waiting for your input.
* [x] A minor one: `mailto` url has been written using HTML rather than markdown. I think this is better to stick to MD as much as we can. This one is already fixed. 

Adding @omazapa who is the original author of the pages.