### PR TITLE
Feb. 9 meeting summary: typo fixed

### DIFF
--- a/organization/_posts/2017-02-09-startup.md
+++ b/organization/_posts/2017-02-09-startup.md
@@ -15,11 +15,11 @@ layout: default
 
     -   About 30 projects (ideas) has been submitted by about 45 mentors from about 17 different organizations.
 
-    -   Next step: The \*organizations\* will be announced and students will start contacting prospective mentors (Feb 27, 2017)
+    -   Next step: The *organizations* will be announced and students will start contacting prospective mentors (Feb 27, 2017)
 
 -   There will be an LHCC Meeting in two weeks from now. A short summary of CWP workshop will be given by Benedikt.
 
--   People informed that several summary talks of the CWP workshop are being given. It would be nice if we should collect material of these talks in \[this page\](http://hepsoftwarefoundation.org/organization/team.html).
+-   People informed that several summary talks of the CWP workshop are being given. It would be nice if we should collect material of these talks in [this page](http://hepsoftwarefoundation.org/organization/team.html).
 
 ## Current Topics
 
@@ -31,7 +31,7 @@ layout: default
 
 -   HEP analysis ecosystem workshop
 
-    -   [*Proposal googledoc*](https://docs.google.com/document/d/1aAGCj_y9in_I-c9yYJ-XX3Qurf0PXH4tFoYmvuCY5tk/edit?usp=sharing)
+    -   [Proposal googledoc](https://docs.google.com/document/d/1aAGCj_y9in_I-c9yYJ-XX3Qurf0PXH4tFoYmvuCY5tk/edit?usp=sharing)
 
     -   It is pretty clear from the doodle poll that the best slot is 22-24 May 2017.
 
@@ -49,7 +49,7 @@ layout: default
 
 -   CMS is trying to get organized for their participation the various WGs and inviting individuals from other experiments to their meetings.
 
--   Started a discussion on how we organize the actual writing of the CWP. Different opinions being expressed: start early with a given overall structure, or start with a bunch of partial \*white papers\* on each topic and try to summarize them on the CWP. We will follow this discussion by e-mail.
+-   Started a discussion on how we organize the actual writing of the CWP. Different opinions being expressed: start early with a given overall structure, or start with a bunch of partial *white papers* on each topic and try to summarize them on the CWP. We will follow this discussion by e-mail.
 
 ## Activity updates
 


### PR DESCRIPTION
Please note that when taking notes into Google Docs to convert them into Markdown with `pandoc`, the Google Docs should not contain any Markdown markup or the corresponding characters will be escaped in the Markdown file, not producing the expected results. In particular, links in the Google Docs must be created in the standard way (CTRL-K or equivalent button), italic must be italicized text in Google Docs...