### PR TITLE
html-proofer: enable check of external links

### DIFF
--- a/.travis-scripts/html-proofer
+++ b/.travis-scripts/html-proofer
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -e # halt script on error
+
+usage () {
+    echo "usage: $(basename $0) [--debug]"
+    exit 2
+}
+
+debug_option=
+
+if [ "$1" == "--debug" ]
+then
+    debug_option="--log-level debug"
+elif [ -n "$1" ]
+then
+    echo "Unsupported option ($1)"
+    usage
+fi
+
+url_ignore_file=$(dirname $0)/url-ignore
+if [ ! -f ${url_ignore_file} ]
+then
+    echo "List of URL to ignore must exist (${url_ignore_file}), even if empty"
+    exit 1
+fi
+
+url_ignore_patterns=
+url_ignore_option=
+# The following construct ensure that the end line is processed if not ending by \n
+while IFS='' read -r url || [[ -n "$url" ]]; do
+    url=$(echo ${url} | sed -e 's/\s*#.*$//')
+    if [ -n "${url}" ]
+    then
+        url=$(echo ${url} | sed -e 's%/%\\/%g' -e 's/\./\\./g' -e 's/\?/\\?/')
+        url_ignore_patterns="${url_ignore_patterns},/${url}/"
+    fi
+done < "${url_ignore_file}"
+url_ignore_patterns=$(echo "${url_ignore_patterns}" | sed -e 's/^,//')
+if [ -n "${url_ignore_patterns}" ]
+then
+    url_ignore_option="--url-ignore ${url_ignore_patterns}"
+fi
+echo "html-proofer url-ignore option: ${url_ignore_option}"
+
+bundle exec jekyll build
+set +e # do not halt script on error
+bundle exec htmlproofer ${url_ignore_option} ${debug_option} --check-html ./_site
+status=$?
+if [ ${status} -ne 0 -a -z "${debug_option}" ]
+then
+    echo ""
+    echo "htmlproofer failed to validate site contents: use --debug for more information"
+fi
+
+exit ${status}

--- a/.travis-scripts/url-ignore
+++ b/.travis-scripts/url-ignore
@@ -1,0 +1,15 @@
+# List of URL to ignore in html-proofer external link check
+# One URL per line, comments allowed as a full line or after the URL.
+# There is only a limited support for URL regexp rather than plain
+# URL : use a regexp only if it is really necessary. But the URL
+# may be a partial URL (ommitting the protocol for example or the
+# end of the URL).
+#
+# Please, DO NOT PUT BROKEN URLs in this file. Only add URLs that
+# cannot be verified successfully by html-proofer despite you
+# validated them with a browser.
+
+https://indico.desy.de/
+http://iml.cern.ch/tiki-index.php
+http://lipforge.ens-lyon.fr/www/crlibm
+https://www.researchgate.net/publication/228732867_Data_transfer_infrastructure_for_CMS_data_taking

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.
-script: ./travis-build
+script: ./.travis-scripts/html-proofer
 
 # branch whitelist, only for GitHub Pages
 branches:

--- a/_gsocproposals/proposal_SixTrackBenchmark.md
+++ b/_gsocproposals/proposal_SixTrackBenchmark.md
@@ -23,7 +23,7 @@ of bottlenecks in the source code, assessment on impact of branches.
 Fortran, calculus, accelerator physics.
 
 ## Web Page
-[cern.ch/sixtrack](http://cern/sixtrack)
+[cern.ch/sixtrack](http://cern.ch/sixtrack)
 
 ## Source Code 
 [github.com/SixTrack/SixTrack](http://github.com/SixTrack/SixTrack)

--- a/_gsocproposals/proposal_SixTrackIntegration.md
+++ b/_gsocproposals/proposal_SixTrackIntegration.md
@@ -24,7 +24,7 @@ test suite and CDash update.
 Fortran, calculus, accelerator physics.
 
 ## Web Page
-[cern.ch/sixtrack](http://cern/sixtrack)
+[cern.ch/sixtrack](http://cern.ch/sixtrack)
 
 ## Source Code 
 [github.com/SixTrack/SixTrack](http://github.com/SixTrack/SixTrack)

--- a/_gsocproposals/proposal_SixTrackLib.md
+++ b/_gsocproposals/proposal_SixTrackLib.md
@@ -25,7 +25,7 @@ bit-level identical results.
 Experience with Fortran, C, OpenCL, CUDA, vectorization techniques.
 
 ## Web Page
-[cern.ch/sixtrack](http://cern/sixtrack)
+[cern.ch/sixtrack](http://cern.ch/sixtrack)
 
 ## Source Code 
 [github.com/SixTrack/SixTrack](http://github.com/SixTrack/SixTrack)

--- a/_gsocproposals/proposal_SixTrackNewModels.md
+++ b/_gsocproposals/proposal_SixTrackNewModels.md
@@ -22,7 +22,7 @@ energy machines and/or machines with radiation effects.
 Fortran, calculus, accelerator physics.
 
 ## Web Page
-[cern.ch/sixtrack](http://cern/sixtrack)
+[cern.ch/sixtrack](http://cern.ch/sixtrack)
 
 ## Source Code 
 [github.com/SixTrack/SixTrack](http://github.com/SixTrack/SixTrack)

--- a/_includes/events.ext
+++ b/_includes/events.ext
@@ -12,4 +12,4 @@
 
   </ul>
 
-See also <a href="https://hepsoftware.org/?popupmode=Events&amp;popupstate=events">HEP S&amp;C community events</a>
+See also <a href="http://hepsoftware.org/?popupmode=Events&amp;popupstate=events">HEP S&amp;C community events</a>

--- a/_includes/sidebar.ext
+++ b/_includes/sidebar.ext
@@ -17,7 +17,7 @@ contact the <a href="mailto:hep-sf-startup-team@googlegroups.com">startup team</
       {% endif %}
     {% endfor %}
     </ol>
-See also <a href='https://hepsoftware.org/?popupmode=Events&popupstate=events'>HEP S&amp;C community events</a>
+See also <a href='http://hepsoftware.org/?popupmode=Events&popupstate=events'>HEP S&amp;C community events</a>
   </div>
 
   <div class="sidebar-module sidebar-module-inset">

--- a/gsoc/project_SixTrack.md
+++ b/gsoc/project_SixTrack.md
@@ -8,7 +8,7 @@ description: |
   High-Luminosity LHC (HL-LHC) upgrade that will be installed in the next decade.
   Sixtrack has been adapted to take advantage of large scale volunteer computing
   resources provided by the
-  [LHC@Home](http://sixtrack.web.cern.ch/SixTrack/www/cern.ch/lhcathome) project.
+  [LHC@Home](http://lhcathome.web.cern.ch) project.
   It has been engineered to give the exact same results after millions of
   operations on several, very different computer platforms. The source code is
   written in Fortran, and is pre-processed by two programs that assemble the code

--- a/organization/_posts/2016-05-04-Workshop-summary.md
+++ b/organization/_posts/2016-05-04-Workshop-summary.md
@@ -851,7 +851,7 @@ Dario: importance of trainings to meet the challenge by increasing existing peop
 
 ### GeantV review
 
--   Clear message from the [*doodle*](http://doodle.com/poll/dhrtyfpbv4miwwup) is preferred date is week of Oct 24-28, probably early that week. Location not yet firmly decided, probably CERN.
+-   Clear message from the Doodle poll that the preferred date is week of Oct 24-28, probably early that week. Location not yet firmly decided, probably CERN.
 
 -   If this doesn’t work for you, and you very much want to attend, let us know
 

--- a/organization/_posts/2016-12-15-startup.md
+++ b/organization/_posts/2016-12-15-startup.md
@@ -18,7 +18,7 @@ layout: default
 
 -   List of registered people sent
 
-    -   [*http://indico.cern.ch/event/570249/page/9149-workshop-registration*](http://indico.cern.ch/event/570249/page/9149-workshop-registration)
+    -   [*http://indico.cern.ch/event/570249/page/9149-workshop-registration*](http://indico.cern.ch/event/570249)
 
 -   Peter has been filling out the agenda with content and names, further updated this week
 

--- a/travis-build
+++ b/travis-build
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -e # halt script on error
-
-bundle exec jekyll build
-# Temporarily disable check of external links as too many are failing
-# FIXME: enable external link checking
-bundle exec htmlproofer --check-html --disable-external --log-level debug ./_site


### PR DESCRIPTION
- travis-build moved to .travis-scripts/html-proofer
- Use .travis-scripts/url-ignore to add exceptions