### PR TITLE
Fix problematic URL in /7/7/2016 startup team meeting summary

### DIFF
--- a/organization/_posts/2016-07-07-startup.md
+++ b/organization/_posts/2016-07-07-startup.md
@@ -58,9 +58,12 @@ layout: default
 
 -   The default policy between what you build and what you find in the system is not yet clear. But it should possible for the maintainer of an install area to decide what packages are acceptable from the ones in the system and what must be rebuilt (picking from the system means a less dependable dependency, also taking the dependencies from Spack ensures a greater testing by the community).
 
--   Pere: what are the next steps? LHCb wants to try it out and have more people in the community to play with it.
+-   Pere: what are the next steps? LHCb wants to try it out and have more people 
+  in the community to play with it.
 
--   Suggestion from Guilherme: consider Gentoo Linux Portage package manager as a means of software distribution [*https://wiki.gentoo.org/wiki/Portage*](https://wiki.gentoo.org/wiki/Portage). Packages already available: [*https://packages.gentoo.org/packages/search?q=sci-physics%2F\**](https://packages.gentoo.org/packages/search?q=sci-physics%2F*) Benedikt encourages Guilherme to discuss it in the packaging WG: may be the topic for one of the next WG meetings.
+-   Suggestion from Guilherme: consider [Gentoo Linux Portage package manager](https://wiki.gentoo.org/wiki/Portage) as a means of software 
+    distribution. Packages already available can be seen on Gentoo [package index](https://packages.gentoo.org/categories).
+    Benedikt encourages Guilherme to discuss it in the packaging WG: may be the topic for one of the next WG meetings.
 
 ### Licencing
 


### PR DESCRIPTION
Fixes problem that showed up in #139 (related to a no longer valid Gentoo url).