### PR TITLE
Update with latest CWP group status

### DIFF
--- a/_activities/cwp.md
+++ b/_activities/cwp.md
@@ -21,7 +21,8 @@ investments required, we are now beginning a community planning process. The
 aim
 is to produce a Community White Paper 
 (CWP) which will describe the community strategy and a roadmap for 
-software and computing R&D in HEP for the 2020s. This activity is organised under the umbrella of the HSF. The LHC experiments and HSF have been 
+software and computing R&D in HEP for the 2020s. This activity is organised under 
+the umbrella of the HSF. The LHC experiments and HSF have been 
 specifically [charged by the WLCG project](/assets/CWP-Charge-HSF.pdf) and
 we are reaching out to other HEP experiments around the world to participate.
 
@@ -31,33 +32,34 @@ we are reaching out to other HEP experiments around the world to participate.
 
 ## Draft WG white papers and status
 
-  * Computing Models, Facilities, and Distributed Computing WG 
-	* Draft WG white paper: [google doc](https://docs.google.com/document/d/1dm5vxejQrKZ19Y-pBLaqBcI_Z_yEN6S0N3Z4UonoTn8/edit?usp=sharing) - available for review
-  * Detector Simulation WG
-	* Executive summary [paper available](https://docs.google.com/document/d/15dyg1H5FMkbAWJf8WC6cXa6X62L1Q9AXLJuRGD-FR00/edit?usp=sharing)
-	* Draft WG white paper: [google doc](https://docs.google.com/document/d/1Qm8btmDti1dcu5G2FMez3J6FLyzv0k6fag0clD25JSo/edit?ts=5977c5fc) - only a few open points
-  * Software Trigger and Event Reconstruction WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1QRO8RA488fwfSg5CSjmvm16-pZpGApSA0l666g_mS_0/edit#) - ready for review (Frozen version: [pdf](https://drive.google.com/open?id=0B8p0qzoMmbwbRFF4RmFtamlCaWs))
-    * Draft WG executive summary: [google doc](https://docs.google.com/document/d/1f1rOFwqRh7FhSB2VXf5hM14r5wHdkIXo3AdBcYkC1qk) - ready for review (Frozen version: [pdf](https://drive.google.com/file/d/0B8p0qzoMmbwbdGRZV0lTUDZHZ3c/view?usp=sharing))   
-  * Visualization WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1dtE2DEdYCWzPaEy_twgSCFdmGxphXMjMcOV0yjI4AKc/edit#heading=h.aywciqdbmlzq) - still writing
-  * Data Access, Organization and Management WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1_YKGs8waBidpS8akmjxEVjV00DThINbJAuVelzk2uHg/edit) - available for review
-  * Machine Learning WG
-    * Draft WG white paper: [Hypothes.is](https://hypothes.is/groups/j9RW8j3i/hep-software-foundation) - submitted for wider community review
-  * Conditions Database WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1yTcw51TOc68DCZQ4AO7o1hBdkPbN5l52ysJgJXNnJl8/edit) - ready for review
-  * Event Processing Frameworks WG 
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/14NMDpzlIKaR_L3dhdRKh3mswA008ahuNxwTs7hiNlBc/edit#heading=h.4mvar3ml92e7) - fairly complete, needs comment resolution
-  * Software Development, Deployment and Validation/Verification WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1EtvAda2bZw5AHjhcqK-2T7bDlvznypZIWL-Bw3X6BWQ/edit?usp=sharing) - finshed, ready for review
-  * Data Analysis and Interpretation WG
-    * Draft WG white paper: [google doc](http://tinyurl.com/y9xrhphx) - still writing
   * Careers, Staffing and Training WG
     * Draft WG white paper: [ShareLaTeX](https://www.sharelatex.com/project/595500273c5204ff35dfdcf9) - still writing
+  * Computing Models, Facilities, and Distributed Computing WG 
+	* Draft WG white paper: [google doc](https://docs.google.com/document/d/1dm5vxejQrKZ19Y-pBLaqBcI_Z_yEN6S0N3Z4UonoTn8/edit?usp=sharing) - **available for review**
+  * Conditions Database WG
+    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1yTcw51TOc68DCZQ4AO7o1hBdkPbN5l52ysJgJXNnJl8/edit) - **available for review**
+  * Data Access, Organization and Management WG
+    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1_YKGs8waBidpS8akmjxEVjV00DThINbJAuVelzk2uHg/edit) - **available for review**
+  * Data Analysis and Interpretation WG
+    * Draft WG white paper: [google doc](http://tinyurl.com/y9xrhphx) - still writing
+  * Data and Software Preservation WG
+    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1IGKQStDZm97PFZJX_N0OuN5cCZ26WOH1Qiiixnq8M-M/edit?usp=sharing)
+  * Detector Simulation WG
+	* Executive summary [paper available](https://docs.google.com/document/d/15dyg1H5FMkbAWJf8WC6cXa6X62L1Q9AXLJuRGD-FR00/edit?usp=sharing) - **available for review**
+	* Draft WG white paper: [google doc](https://docs.google.com/document/d/1Qm8btmDti1dcu5G2FMez3J6FLyzv0k6fag0clD25JSo/edit?ts=5977c5fc) - only a few open points, **available for review**
+  * Event Processing Frameworks WG 
+    * Draft WG white paper: [google doc](https://docs.google.com/document/d/14NMDpzlIKaR_L3dhdRKh3mswA008ahuNxwTs7hiNlBc/edit#heading=h.4mvar3ml92e7) - fairly complete, needs executive summary
+  * Machine Learning WG
+    * Draft WG white paper: [Hypothes.is](https://hypothes.is/groups/j9RW8j3i/hep-software-foundation) - submitted for wider community review
   * Physics Generators WG
-    * Draft WG white paper: [Overleaf](https://www.overleaf.com/read/wyyybnvxyfyn) - still writing
-  
+    * Draft WG white paper: [Overleaf](https://www.overleaf.com/read/wyyybnvxyfyn) - still writing  
+  * Software Development, Deployment and Validation/Verification WG
+    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1EtvAda2bZw5AHjhcqK-2T7bDlvznypZIWL-Bw3X6BWQ/edit?usp=sharing) - finshed, **available for review**
+  * Software Trigger and Event Reconstruction WG
+    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1QRO8RA488fwfSg5CSjmvm16-pZpGApSA0l666g_mS_0/edit#) - **available for review** (Frozen version: [pdf](https://drive.google.com/open?id=0B8p0qzoMmbwbRFF4RmFtamlCaWs))
+    * Draft WG executive summary: [google doc](https://docs.google.com/document/d/1f1rOFwqRh7FhSB2VXf5hM14r5wHdkIXo3AdBcYkC1qk) - **available for review** (Frozen version: [pdf](https://drive.google.com/file/d/0B8p0qzoMmbwbdGRZV0lTUDZHZ3c/view?usp=sharing))   
+  * Visualization WG
+    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1dtE2DEdYCWzPaEy_twgSCFdmGxphXMjMcOV0yjI4AKc/edit#heading=h.aywciqdbmlzq) - still writing
 
 ## Working Groups
 

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -21,7 +21,7 @@ The HEP Software Foundation (HSF) facilitates coordination and common efforts in
 
 <!-- Important announcements from announcements/_posts -->
 <div>
-The HSF is now beginning a community process to develop a consensus roadmap for HEP Software and Computing R&amp;D for the 2020s. More infomation about this can be found on the <a href="{{site.baseurl}}/activities/cwp.html">Community White Paper (CWP)</a> page on the HSF site.
+The HSF is guiding a community process to develop a consensus roadmap for HEP Software and Computing R&amp;D for the 2020s. More information about this can be found on the <a href="{{site.baseurl}}/activities/cwp.html">Community White Paper (CWP)</a> page on the HSF site.
 </div>
 <hr>
   {% assign sitedate = site.time | date: "%Y-%m-%d"   %}

--- a/cwp/cwp-working-groups.md
+++ b/cwp/cwp-working-groups.md
@@ -6,14 +6,19 @@ layout: default
 
 ## Community White Paper (CWP) Working Groups
 
-  During October, 2016, the process of forming CWP working groups has begun. We are letting the working groups self-organize with a bit of help from the HEP experiment software/computing coordinators and the HSF startup team. The first step for each working group is to formulate a charge to describe the challenges in that area and questions which need to be answered to produce a roadmap for the CWP. 
+In October, 2016, the process of forming CWP working groups began. Working groups self-organized with some help from the HEP experiment software/computing coordinators and the HSF startup team. Charges were formulated to describe the challenges in that area and questions which need to be answered to produce a roadmap for the CWP. 
 
-  The working group charges should be world-visible for reading. If you would
-like to edit them, you will need to join the [hsf-community-white-paper](https://groups.google.com/forum/#!forum/hsf-community-white-paper) Google group and
-login as your google user. If you would like organize an additional working group, please post to the [hsf-community-white-paper](https://groups.google.com/forum/#!forum/hsf-community-white-paper) Google group.
+The working group charges and working group document should be world-visible for reading. Please
+join the 
+[hsf-community-white-paper](https://groups.google.com/forum/#!forum/hsf-community-white-paper)
+Google group if you would like to edit or comment. For those groups that chose not to use
+Google Docs, please contact the group for the best way to comment or contribute.
 
 **Note: it is possible to register to all the Google groups without a Google account. In this case, send an empty email (subject and contents ignored) to the group email, adding `+subscribe` after the group name. (e.g. hsf-cwp-software-development+subscribe@googlegroups.com).**
 
+As the CWP process is now concluding, this page is mostly for information and
+to capture some history now. Please see the [CWP status page](../activities/cwp.html) for the latest
+status of working group papers.
 
 
 <!-- ======================================================= -->
@@ -122,7 +127,7 @@ Google group: hsf-cwp-software-development@googlegroups.com [(link to subscribe)
 
 Plans:
 
-Draft WG white paper: [google doc](https://indico.cern.ch/event/613093/contributions/2615326/attachments/1482758/2300163/go)
+Draft WG white paper: [google doc](https://docs.google.com/document/d/1EtvAda2bZw5AHjhcqK-2T7bDlvznypZIWL-Bw3X6BWQ/edit?usp=sharing); original [dropbox paper](https://paper.dropbox.com/doc/CWP-WG-Software-development-Deployment-and-ValidationVerification-3fHuGjHGETMIHv4pKQrPR) has been archived (it has some interesting comment threads)
 
 <!-- ======================================================= -->
 
@@ -152,6 +157,8 @@ Charge: [Google Doc](https://docs.google.com/document/d/15trJhLKqb9OcN55WIPfmdH8
 Google group: hsf-cwp-data-preservation@googlegroups.com [(link to subscribe)](https://groups.google.com/d/forum/hsf-cwp-data-preservation)
 
 Plans:
+
+Draft WG notes: [google doc](https://docs.google.com/document/d/1IGKQStDZm97PFZJX_N0OuN5cCZ26WOH1Qiiixnq8M-M/edit?usp=sharing)
 
 <!-- ======================================================= -->
 


### PR DESCRIPTION
There is an annoying line ending change in this MR, but if you use the "rich diff" option it shows the more relevant changes.

- Reorganised the status list to be alphabetical
- Groups where the document is ready for review get a bold highlight
