### PR TITLE
Dockerise html proofing and fix broken links

### DIFF
--- a/.travis-scripts/html-proofer
+++ b/.travis-scripts/html-proofer
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e # halt script on error
 
 usage () {
     echo "usage: $(basename $0) [--debug]"
@@ -17,33 +16,7 @@ then
     usage
 fi
 
-url_ignore_file=$(dirname $0)/url-ignore
-if [ ! -f ${url_ignore_file} ]
-then
-    echo "List of URL to ignore must exist (${url_ignore_file}), even if empty"
-    exit 1
-fi
-
-url_ignore_patterns=
-url_ignore_option=
-# The following construct ensure that the end line is processed if not ending by \n
-while IFS='' read -r url || [[ -n "$url" ]]; do
-    url=$(echo ${url} | sed -e 's/\s*#.*$//')
-    if [ -n "${url}" ]
-    then
-        url=$(echo ${url} | sed -e 's%/%\\/%g' -e 's/\./\\./g' -e 's/\?/\\?/')
-        url_ignore_patterns="${url_ignore_patterns},/${url}/"
-    fi
-done < "${url_ignore_file}"
-url_ignore_patterns=$(echo "${url_ignore_patterns}" | sed -e 's/^,//')
-if [ -n "${url_ignore_patterns}" ]
-then
-    url_ignore_option="--url-ignore ${url_ignore_patterns}"
-fi
-echo "html-proofer url-ignore option: ${url_ignore_option}"
-
 bundle exec jekyll build
-set +e # do not halt script on error
 bundle exec htmlproofer ${url_ignore_option} ${debug_option} --check-html ./_site
 status=$?
 if [ ${status} -ne 0 -a -z "${debug_option}" ]

--- a/.travis-scripts/url-ignore
+++ b/.travis-scripts/url-ignore
@@ -1,17 +1,8 @@
-# List of URL to ignore in html-proofer external link check
-# One URL per line, comments allowed as a full line or after the URL.
-# There is only a limited support for URL regexp rather than plain
-# URL : use a regexp only if it is really necessary. But the URL
-# may be a partial URL (ommitting the protocol for example or the
-# end of the URL).
+# Do not use this file to suppress checks against URLs any more.
+# Instead please add the tag "data-proofer-ignore" to your link,
+# see 
+# https://github.com/gjtorikian/html-proofer#ignoring-content
 #
-# Please, DO NOT PUT BROKEN URLs in this file. Only add URLs that
-# cannot be verified successfully by html-proofer despite you
-# validated them with a browser.
-
-https://indico.desy.de/
-http://iml.cern.ch/tiki-index.php
-http://lipforge.ens-lyon.fr/www/crlibm
-https://www.researchgate.net/publication/228732867_Data_transfer_infrastructure_for_CMS_data_taking
-https://sciencegateways.org
-http://science.energy.gov
+# To use this technique with a markdown URL, you can use the
+# kramdown extension that adds tags to URLs, e.g.
+# [link text](http://valid.but.unferifiable.com/){:data-proofer-ignore}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
-language: ruby
-rvm:
-- 2.2
+sudo: required
 
-# Assume bundler is being used, therefore
-# the `install` step will run `bundle install` by default.
-script: ./.travis-scripts/html-proofer
+language: ruby
+
+services:
+  - docker
+  
+before_install:
+  - docker pull graemeastewart/hsf-jekyll
+ 
+ # Skip install as the container does all the work
+install: /bin/true
+ 
+script:
+  - docker run --volume $(pwd):/srv/jekyll --interactive --tty graemeastewart/hsf-jekyll /bin/sh -c /srv/jekyll/.travis-scripts/html-proofer
 
 # branch whitelist, only for GitHub Pages
 branches:
   only:
   - master
-
-env:
-  global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
-
-cache: bundler
-
-sudo: false

--- a/_gsocproposals/proposal_TMVAmlr.md
+++ b/_gsocproposals/proposal_TMVAmlr.md
@@ -8,7 +8,9 @@ organization:
 ---
 
 # Description
-[mlr](https://mlr-org.github.io/) is an [R](https://cran.r-project.org/) package that integrates almost all machine learning packages in R. [RMVA](http://oproject.org/RMVA) is a set of plugins for TMVA based on [ROOTR](http://oproject.org/ROOT+R) that allows the use of R in TMVA. The idea is to update the library RMVA to use mlr.
+[mlr](https://mlr-org.github.io/) is an [R](https://cran.r-project.org/) package that integrates almost all machine learning packages in R. [RMVA](http://oproject.org/RMVA){:data-proofer-ignore} is a set of plugins for TMVA based on [ROOTR](http://oproject.org/ROOT+R){:data-proofer-ignore} that allows the use of R in TMVA. The idea is to update the library RMVA to use mlr.
+
+<!-- oproject is very slow and times out on html-proofer --> 
 
 ## Task ideas
  * Write BaseMethod class for mlr package.

--- a/forum_ml.md
+++ b/forum_ml.md
@@ -17,13 +17,13 @@ The Inter-Experimental LHC Machine Learning Working Group [IML](http://iml.cern.
 -  Series of dedicated LHC ML challenges to further strengthen & grow MML-HEP interaction, so we can more effectively collaborate
 
 ## Website
-- [IML](http://iml.cern.ch/tiki-index.php)
+- [IML](http://iml.web.cern.ch/)
 
 ## Mailing List
 - [lhc-machinelearning-wg@cern.ch](mailto:lhc-machinelearning-wg@cern.ch)
 
 ## Meetings and IML Events
--  [Working group meetings](http://iml.cern.ch/tiki-index.php?page=Indico)
+-  [Working group meetings](http://iml.web.cern.ch/meetings)
 
 ## Related Events in HEP
 - [Second Machine Learning High Energy Physics Summer School 2016](https://indico.cern.ch/event/497368/), 20-26 June 2016 at Lund University

--- a/forums.md
+++ b/forums.md
@@ -60,7 +60,7 @@ beneficial for all LHC experiments as well as a forum where on-going work and re
 are discussed by the community.
 
 - The mailing list is **lhc-machinelearning-wg@cern.ch**
-- Working [group meetings](http://iml.cern.ch/tiki-index.php?page=Indico)
+- [Working group meetings](http://iml.web.cern.ch/meetings)
 
 ---
 

--- a/gsoc/project_SixTrack.md
+++ b/gsoc/project_SixTrack.md
@@ -13,11 +13,11 @@ description: |
   operations on several, very different computer platforms. The source code is
   written in Fortran, and is pre-processed by two programs that assemble the code
   blocks and provide automatic differentiation of the equation of motions. The
-  code relies on the [crlibm](http://lipforge.ens-lyon.fr/www/crlibm/) library,
+  code relies on the `crlibm` library,
   careful arrangement of parenthesis, dedicated input/output and selected
   compilation flags for the most common compilers to provide identical results on
   different platforms and operating systems. An option enables the use of the
-  [Boinc](http://lipforge.ens-lyon.fr/www/crlibm/) library for volunteer
+  Boinc library for volunteer
   computing. A running environment SixDesk is used to generate input files, split
   simulations for LHC@Home (link sends e-mail) or CERN cluster and collect the
   results for the user. SixTrack is licensed under LGPLv2.1.


### PR DESCRIPTION
Use a container for testing HTML links. This uses a slightly modified version of the jekyll/jekyll container, which is based on Alpine Linux.

(Once this works we should add the Dockerfile somewhere.)
