### PR TITLE
Add short HOWTO for editing the community calendar

### DIFF
--- a/_includes/navbar.ext
+++ b/_includes/navbar.ext
@@ -31,6 +31,7 @@
                   <li><a href="/technical_notes.html">Technical Notes</a></li>
                   <li><a href="/newsletter.html">Newsletter</a></li>
                   <li><a href="/organization/minutes.html">Meeting Notes</a></li>
+                  <li><a href="/calendar.html">Community Calendar Editing</a></li>
                   <li class="divider"></li>
                   <li><a href="http://www.hepsoftware.org">HEP S&amp;C Knowledge Base</a></li>
                 </ul>

--- a/_includes/navbar.ext
+++ b/_includes/navbar.ext
@@ -31,7 +31,6 @@
                   <li><a href="/technical_notes.html">Technical Notes</a></li>
                   <li><a href="/newsletter.html">Newsletter</a></li>
                   <li><a href="/organization/minutes.html">Meeting Notes</a></li>
-                  <li><a href="/calendar.html">Community Calendar Editing</a></li>
                   <li class="divider"></li>
                   <li><a href="http://www.hepsoftware.org">HEP S&amp;C Knowledge Base</a></li>
                 </ul>

--- a/calendar.md
+++ b/calendar.md
@@ -4,9 +4,9 @@ author: "Graeme Stewart"
 layout: default
 ---
 
-The HSF [Community Calendar](https://calendar.google.com/calendar/embed?src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com&ctz=Europe/Amsterdam)
+The HSF [Community Calendar](https://calendar.google.com/calendar/embed?src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com){:target="_hsf_calendar"}
 can be edited by people in the [HSF Startup Team](https://groups.google.com/forum/#!forum/hep-sf-startup-team)
-Google Group.
+Google Group **TBD** an additional group **TBD**.
 
 The most straight forward way to do this is to 
 
@@ -19,11 +19,7 @@ https://calendar.google.com/calendar/ical/e4v33e1a1drbncdle1n03ahpcs%40group.cal
 ```
 
 Then you will have the ability to view events in the community 
-calendar and, if you are in the startup
-team group, add them. 
+calendar and, if you are in an editing group, add them. 
 
-Please ask to join the startup
-team if you would like to add events. 
-You can join the startup team then disable email notifications
-if you don't wish to be troubled by the other traffic on the list.
+Please ask to join one of the editing groups if you would like to add events. 
  

--- a/calendar.md
+++ b/calendar.md
@@ -1,0 +1,29 @@
+---
+title: "Community Calendar - Editing"
+author: "Graeme Stewart"
+layout: default
+---
+
+The HSF [Community Calendar](https://calendar.google.com/calendar/embed?src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com&ctz=Europe/Amsterdam)
+can be edited by people in the [HSF Startup Team](https://groups.google.com/forum/#!forum/hep-sf-startup-team)
+Google Group.
+
+The most straight forward way to do this is to 
+
+- go to your [Google Calendar page](https://calendar.google.com/calendar)
+- select *Other Calendars* -> *Add by URL*
+- add the [following URL](https://calendar.google.com/calendar/ical/e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com/public/basic.ics)
+
+```
+https://calendar.google.com/calendar/ical/e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com/public/basic.ics
+```
+
+Then you will have the ability to view events in the community 
+calendar and, if you are in the startup
+team group, add them. 
+
+Please ask to join the startup
+team if you would like to add events. 
+You can join the startup team then disable email notifications
+if you don't wish to be troubled by the other traffic on the list.
+ 

--- a/calendar.md
+++ b/calendar.md
@@ -6,7 +6,7 @@ layout: default
 
 The HSF [Community Calendar](https://calendar.google.com/calendar/embed?src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com){:target="_hsf_calendar"}
 can be edited by people in the [HSF Startup Team](https://groups.google.com/forum/#!forum/hep-sf-startup-team)
-Google Group **TBD** an additional group **TBD**.
+or in the [HSF Calendar Editors Group](https://groups.google.com/forum/#!forum/hep-sf-calendar-editors) Google Groups.
 
 The most straight forward way to do this is to 
 
@@ -21,5 +21,5 @@ https://calendar.google.com/calendar/ical/e4v33e1a1drbncdle1n03ahpcs%40group.cal
 Then you will have the ability to view events in the community 
 calendar and, if you are in an editing group, add them. 
 
-Please ask to join one of the editing groups if you would like to add events. 
- 
+Please ask to join one of the editing groups if you would like to add events
+for your experiment or community.

--- a/get_involved.md
+++ b/get_involved.md
@@ -47,6 +47,11 @@ right place for it, feel free to contact the
 You are very welcome to extend this website and add information to it. You can
 find instructions on how to do it [here](/howto-website.html).
 
+## Add events to the community calendar
+
+See [this short guide](/calendar.html) for how to add next events to the calendar.
+
+
 ## Contributing to the HSF S&C Knowledge Base
 
 The HSF provides a S&C knowledge base at 


### PR DESCRIPTION
This PR adds a short section on how to edit the community calendar, publicising the URL that you need to use to add the HSF calendar to your own calendar application. Instructions are given for Google Calendar.

I tried the URL with a throw-away Google account that I have and it would not let me add events, so the editing permissions do seem to be locked down (@pelmer can probably confirm it's the startup team).

I added this link under the Communication navigation item.