### PR TITLE
Packaging meeting 12 and update activity page

### DIFF
--- a/_activities/packaging.md
+++ b/_activities/packaging.md
@@ -4,9 +4,15 @@ layout: plain
 redirect_from: /workinggroups/2015/11/04/packaging.html
 ---
 
-The software packaging and distribution activity and working group is getting underway to address common issues, tools, and approaches, convened by Liz Sexton-Kennedy (FNAL) and Benedikt Hegner (CERN). The activity was launched with a meeting on Feb 25 2015. All are welcome to join the forum and participate:
+The software packaging and distribution activity and working group addresses common issues, tools, and approaches to building and distributing the software stacks used by HEP experiments.
 
-[Software Packaging Tools Discussion Forum](https://groups.google.com/forum/#!forum/hep-sf-packaging-wg)
+The group is currently convened by Graeme Stewart (CERN), who took over from Liz Sexton-Kennedy (FNAL) and Benedikt Hegner (CERN) in October 2017.
+
+Everyone is welcome to join the forum and participate:
+
+[Software Packaging Tools Discussion Forum](https://groups.google.com/forum/#!forum/hep-sf-packaging-wg){:target="_hsf_packaging_forum}
+
+[Packaging Group Indico](https://indico.cern.ch/category/7975/){:target="_hsf_packaging_indico"}
 
 # Goals
 The aim of this working group is to foster communication and exchange among the experiments' librarians. We identified various topics to work on. Some of them are:
@@ -14,8 +20,6 @@ The aim of this working group is to foster communication and exchange among the 
   1. Common build recipes and tools
   2. How to take most advantage of technologies like dockers
   3. Exchange of experience with the CMake eco-system
-
-We started by tackling the first item.
 
 ## Common Build Recipes and Tools
 Software development in high energy physics follows the paradigm of open-source software (OSS). Experiments as well as the theory community heavily rely on software being developed outside of the field. Creating a consistent and working stack out of 100s of packages, on a variety of platforms is a non-trivial task. Within the field multiple technical solutions exist to configure and build those stacks. None of this work is experiment specific and our working group agrees that this effort is being duplicated.
@@ -34,6 +38,7 @@ We held various meetings to look at the existing build and packaging solutions
 | [18.11.2015](https://indico.cern.ch/event/462334/) | Conda                |
 | [10.02.2016](https://indico.cern.ch/event/484006/) | Spack                |
 | [02.11.2017](https://indico.cern.ch/event/581338/) | Gentoo's Portage     |
+| [18.10.2017](https://indico.cern.ch/event/672745/) - [minutes](/organization/2017/10/18/packaging.html)| Next Steps |
 
 During these meetings we looked at the following community-driven projects
 
@@ -52,7 +57,7 @@ and the following open-source projects
   * [Portage](https://wiki.gentoo.org/wiki/Project:Portage)
   * [Spack](https://github.com/LLNL/spack) 
 
-The summary of our analysis has been summarized in a [Technical note on Build Tools](/technical_notes.html)
+The summary of our initial findings is found in the [Technical note on Build Tools](/technical_notes.html).
 
 ## Existing build recipes
 

--- a/organization/_posts/2017-10-18-packaging.md
+++ b/organization/_posts/2017-10-18-packaging.md
@@ -1,0 +1,48 @@
+---
+title: "HSF Packaging Group Meeting #12, October 18, 2017"
+layout: default
+---
+
+# HSF Packaging Group Meeting #12, October 18, 2017
+
+#### *Present*: Graeme Stewart, Benedikt Hegner, Liz Sexton-Kennedy, Guilherme Amadio, Pere Mato, Patricia Mendez Lorenzo, Javier Cervantes Villanueva, Marco Clemencic, Ben Couturier, Ben Morgan, Christopher Green, Jim Amundson, Patrick Gartung, David Lange, Emil Obreshkov, Shahzad Muzaffar, Oana Boeriu, Joel Closier
+
+#### [Indico Agenda and Presentations](https://indico.cern.ch/event/672745/){:target="_hsf_packaging_12"}
+
+## Introduction
+
+* It was agreed that containers are an important topic for the group.
+
+## Progress Reports
+
+### Spack
+
+* PGP signing is much more important for HPCs. HEP tends to have a trusted build chain managed by the same team, from checkout to CVMFS deployment.
+* Relocatable build caches added to Spack, which was one of the missing features identified during the initial review.
+* Additional topic on moving CMSSW from scram to CMake. Development environment is still missing.
+* Pere: questions on relocation - how is that done? A: relative RPATH and text files get a path replacement at install time (rewriting the original file).
+* Guilherme: what if the relocated RPATH is bigger than the original one? A: On MacOS you can set size. On Linux patchelf allows to use a bigger one. If path bigger than place reserved, you append on the end. Thus not a problem in practice.
+* RPATH vs. RUNPATH discussion: for a development environment RUNPATH would be strongly favoured.
+
+### SpackDev
+
+* Presented how to set up a development environment with SpackDev. There is an added tool to ease building against system packages.
+* Graeme: Can the working package set be updated? A: Not at the moment, but this feature is envisaged.
+* What’s the definition of a "package"? SpackDev for packages as standalone externals or experiments' notion of packages as a subset of the code in the experiment application. A: This is not entirely scoped out yet. *Agreed on follow-up discussion on that.*
+
+### Portage
+
+* Presentation: prefixes can depend on each other. Unclear if this just layering of one prefix on top of another or a composable set of compatible prefixes. Should be followed up.
+* Pere: How likely is interference between standard environment and portage environment? A: System tries to keep this well separated, by using RPATH for its own artifacts, so it should be quite safely setup.
+* Ben Morgan: how to choose between multiple versions of the same package? A: Use `eselect` to set python and/or compiler version. Not so clear for libraries.
+* If one wanted to build different combinations of non-leaf packages there may be scaling issues and unnecessary builds.
+* Jim: Singularity could be used as part of environment decoupling.
+* Ben Morgan: reminded of views in Spack (which exist in LCGCMake as well). 
+* How to define the versions to build ->  portage-sets; allows to set consistent versions
+
+## Next Steps
+
+* Jim/Ben - Containerisation / continuous integration as follow up items
+* Meeting in two weeks again. same time, probably focusing on Spack.
+* Portage will be followed up after that.
+* There is an open call for a second convener for the group to join Graeme.


### PR DESCRIPTION
Add minutes from meeting 12 of the group (to publish in the meeting buffer).

Update group convenor and make some minor edits to the group's page on the website.
