### PR TITLE
Packaging minutes 2017 11 29

### DIFF
--- a/_activities/packaging.md
+++ b/_activities/packaging.md
@@ -8,41 +8,25 @@ The software packaging and distribution activity and working group addresses com
 
 The group is currently convened by Ben Morgan (Warwick) and Graeme Stewart (CERN), who took over from Liz Sexton-Kennedy (FNAL) and Benedikt Hegner (CERN) in October 2017.
 
-Everyone is welcome to join the forum and participate:
+# Getting Involved
 
-[Software Packaging Tools Discussion Forum](https://groups.google.com/forum/#!forum/hep-sf-packaging-wg){:target="_hsf_packaging_forum}
+Everyone is welcome to participate and contribute on the forum and to the ongoing meetings:
 
-[Packaging Group Indico](https://indico.cern.ch/category/7975/){:target="_hsf_packaging_indico"}
+[Packaging Group Discussion Forum](https://groups.google.com/forum/#!forum/hep-sf-packaging-wg){:target="_hsf_packaging_forum}
+
+[Packaging Group Meetings Indico](https://indico.cern.ch/category/7975/){:target="_hsf_packaging_indico"}
 
 # Goals
-The aim of this working group is to foster communication and exchange among the experiments' librarians. We identified various topics to work on. Some of them are:
+The aim of this working group is to foster communication and exchange among the experiments' librarians. We identified various topics to work on, including
 
   1. Common build recipes and tools
-  2. How to take most advantage of technologies like dockers
+  2. How to take most advantage of technologies like containers
   3. Exchange of experience with the CMake eco-system
 
 ## Common Build Recipes and Tools
 Software development in high energy physics follows the paradigm of open-source software (OSS). Experiments as well as the theory community heavily rely on software being developed outside of the field. Creating a consistent and working stack out of 100s of packages, on a variety of platforms is a non-trivial task. Within the field multiple technical solutions exist to configure and build those stacks. None of this work is experiment specific and our working group agrees that this effort is being duplicated.
 
-We held various meetings to look at the existing build and packaging solutions
-
-{:.table .table-hover .table-condensed .table-striped}
-| Date                                              | Main topic            |
-| ------------------------------------------------- | --------------------- |
-| [25.2.2015](https://indico.cern.ch/event/373973/) | Brainstorming session |
-| [2.6.2015](https://indico.cern.ch/event/398344/)  | DUNE approach         |
-| [9.6.2015](https://indico.cern.ch/event/400272)   | LCGCMake              |
-| [16.6.2015](https://indico.cern.ch/event/402229/) | cmsBuild              |
-| [23.6.2015](https://indico.cern.ch/event/403790/) | SciSoft, Contractor   |
-| [4.11.2015](https://indico.cern.ch/event/457365/) | AliBuild              |
-| [18.11.2015](https://indico.cern.ch/event/462334/) | Conda                |
-| [10.02.2016](https://indico.cern.ch/event/484006/) | Spack                |
-| [02.11.2017](https://indico.cern.ch/event/581338/) | Gentoo's Portage     |
-| [18.10.2017](https://indico.cern.ch/event/672745/) - [minutes](/organization/2017/10/18/packaging.html)| Next Steps |
-| [01.11.2017](https://indico.cern.ch/event/674780/) - [minutes](/organization/2017/11/01/packaging.html)| Test Stack, Spack, SuperNEMO use case |
-| [15.11.2017](https://indico.cern.ch/event/678307/) - [minutes](/organization/2017/11/15/packaging.html)| Test Stack, Packaging Use Cases |
-
-During these meetings we looked at the following community-driven projects
+We held [an initial series of meetings](https://indico.cern.ch/category/7975/) to look at the existing build and packaging solutions, including the community-driven projects
 
   * [aliBuild](http://alisw.github.io/alibuild/)
   * [cmsBuild](https://github.com/cmsbuild/cmsdist)
@@ -51,7 +35,7 @@ During these meetings we looked at the following community-driven projects
   * Contractor (no public documentation)
   * SciSoft (no public documentation)
 
-and the following open-source projects
+and the general open-source projects
 
   * [Conda](http://conda.pydata.org/docs/)
   * [homebrew](http://brew.sh/)
@@ -70,7 +54,6 @@ The summary of our initial findings is found in the [Technical note on Build Too
   * [conda recipes by Brett Viren](https://github.com/brettviren/lbne-conda) (deprecated)
   * [aliDist recipes](https://github.com/alisw/alidist)
   * [LCGCMake recipes](https://gitlab.cern.ch/sft/lcgcmake)
-
 
 # Other resources
 

--- a/organization/_posts/2017-11-29-packaging.md
+++ b/organization/_posts/2017-11-29-packaging.md
@@ -1,0 +1,85 @@
+---
+title: "HSF Packaging Group Meeting #15, November 29, 2017"
+layout: default
+---
+
+# HSF Packaging Group Meeting #15, November 29, 2017
+
+#### *Present*: Graeme Stewart, Lukas Heinrich, Oana Boeriu, Rafal Pacholek, Jakob Blomer, Geri Ganis, Javier Cervantes Villanueva, Guilherme Amadio, Giulio Eulisse, Ben Morgan, Radu Popescu, Ben Couturier, Attila Krasznahorkay, Emil Obreshkov, Chris Green, Patrick Gartung, Pere Mato
+
+#### [Indico Agenda and Presentations](https://indico.cern.ch/event/681894/){:target="_hsf_packaging_15"}
+
+## Introduction
+* Next meeting scheduled for [13th December 2017](https://indico.cern.ch/event/684972/)
+  * Will focus on CVMFS/Containers/Deployment, with presentation from CVMFS developers.
+* Graeme and Ben will draft an abstract on Packaging Use Cases/Tool Assessment for [CHEP 2018](http://chep2018.org)
+  * Will present at next meeting for comments/feedback
+  * Not a paper on any specific tool - expect that people will submit their own abstracts on those.
+* Noted second draft of HSF White Paper open.
+  * Encourage people in this WG to read and comment, especially Software Development.
+  * Also for people to sign - don’t have to have contributed to the content to sign.
+* Update on Use Cases Document
+  * Good feedback and comments since last time, thanks to contributors!
+  * Common agreement on "must have" requirements: specify build options for dependencies,
+    reuse of binary artifacts, setup of runtime "views".
+  * Clarification on: global build options, recipe hierarchy, install relocation (with example
+    implementations), development environment.
+  * Many comments are useful in their own right, so need to capture this information
+    somewhere other than a Google Docs comment thread.
+  * Clarifications with Giulio Eulisse on his comments
+    * On sources, felt important to have a self-managed backup of third-party sources.
+      Guarantees future availability, plus allowing patching. Comment from ATLAS
+      that they also install package sources as part of their package/distribution
+      pipeline.
+    * On reducing command line options, this is to keep major things like switching
+      compiler part of the recipe.
+    * On recipes, importance is to ensure that older packages can be rebuilt in the future.
+      E.g. in Alibuild, Alibuild as it is now can build Alibuild recipes from N years ago.
+  * Clear that we need to identify "actors" in the Use Cases, e.g. librarian, end user.
+
+## Presentation from Oana: ATLAS Releases: Build, Packaging and Deployment - short overview
+* ATLAS offline code is split into many, many units of code called “packages” (usually implementing some particular classes and building a small number of libraries). The full offline Athena release has about 2000 packages.
+* New way of building Athena is quite simple. LCG release is a base, then build AtlasExternals, then Gaudi, then the rest of Athena.
+* Build of Athena bootstraps using AtlasSetup  (sets up gcc, cmake version etc). A few helper scripts used for building whole of Athena, or subsets - output is rpm, from CPack.
+* Nightly rpms are release candidates - copied to EOS. Distribution to CVMFS via Python script. Each nightly build put into date-time tagged directories, under this are the Athena, AthenaExternals, Gaudi. LCG, Externals, tdaq are common over a range of Nightlies
+* Also allow private builds to be distributed over CVMFS
+* Future: looking at ways to save AtlasExternals binary artifacts. Reuse? Looking at Nexus, git LSF. Breaking up large rpms. Include build of LCG
+
+### Discussion
+* Microsoft has released source code for their Git vistual filesystem (GVFS). There is a project on GitHub to port this to Mac and then Linux. Will be a talk on this at CVMFS Workshop in January. Background: Windows source code is very large, so using a Virtual File System to only checkout files when touched.
+* In ATLAS, nightlies always built from scratch both for security and to work around some issues with incremental builds seen in continuous integration. But now in a position to seriously consider incremental nightlies as well.
+* Discussion on installing directly on CVMFS: Is an issue with relocatability, need to have consistent mount points, and of course a writable CVMFS repository. Currently binaries local to build machine, packaged, then uploaded to EOS.
+* Nexus: can store binary artifacts, then can check existence of required binary when/if needed later. Tool to be investigated.
+
+## Presentation from Lukas: Containers in ATLAS
+* Containers and Package Managers solve related, but largely orthogonal problems
+* PMs main unit of distribution is a software package with declared dependencies,
+  each operation is a filesystem change. Packages interface with each other via
+  low level ABIs.
+* Containers main unit of distribution is an filesystem, image of which is sequence
+  of package manager and other operations. Containers interface with each other via
+  abstract file/REST/data server/message queuese
+* Good fit in HEP: global distribution of a complex stack that uses significant OS component to a wide range of systems that we don’t manage like the Grid, HPC user laptops.
+* User developed analysis software has different requirements - often a mix between stages inside release, own code that might require specific directory structure.
+  Physics reproducibility is important.
+* Two approaches in ATLAS for images:
+  * "Fat": Completely self-contained, local on disk, no network or local cvmfs install needed. But large (10GB+).
+  * "Thin": Only provide OS, domain software from host install of CVMFS - needs network, and no immediate knowledge of what bits in CVMFS are used.
+* Build both as part of nightlies for offline and analysis releases, distributed via Docker Hub.
+* Work on CVMFS Graph Driver - “Fat” Image, can be used directly, but also deployed over CVMFS. Docker can then just pull the bits its needs.
+* In use for local development, especially on non-supported platforms.
+* In use for CI - easy integration on common platforms
+* Also for grid deployment - using Singularity as container runtime. HPC may lack networked filesystems like CVMFS, but can support containers
+* Using for Analysis Preservation - CERN Analysis Preservation Portal. Kubernetes cluster.
+* Training: Easy entry point for new collaboration members.
+
+### Discussion
+* Size of "Fat" images depends on domain: User Analysis (small, ~2GB total) and Reconstruction (large ~20GB).
+* How to track provenance of an image? In Images, have each layer was created, but not deterministic. Then the package manager layer, e.g. graph based deterministic.
+* Some development to run docker images without root privileges, e.g. uDocker.
+
+## AOB
+* [Next meeting](https://indico.cern.ch/event/684972/) in 2 weeks, 13th December.
+* Apologies to Guilherme on overrun - guide to using demo Portage Docker/CVMFS
+  installs will be distributed, presentation at next meeting.
+

--- a/organization/_posts/2017-11-29-packaging.md
+++ b/organization/_posts/2017-11-29-packaging.md
@@ -46,7 +46,7 @@ layout: default
 * Future: looking at ways to save AtlasExternals binary artifacts. Reuse? Looking at Nexus, git LSF. Breaking up large rpms. Include build of LCG
 
 ### Discussion
-* Microsoft has released source code for their Git vistual filesystem (GVFS). There is a project on GitHub to port this to Mac and then Linux. Will be a talk on this at CVMFS Workshop in January. Background: Windows source code is very large, so using a Virtual File System to only checkout files when touched.
+* Microsoft has released [source code](https://github.com/Microsoft/GVFS) for their Git virtual filesystem (GVFS). There is a [project with GitHub to port this to Mac and then Linux](https://arstechnica.com/gadgets/2017/11/microsoft-and-github-team-up-to-take-git-virtual-file-system-to-macos-linux/). Will be a talk on this at CVMFS Workshop in January. Background: Windows source code is very large, so using a Virtual File System to only checkout files when touched.
 * In ATLAS, nightlies always built from scratch both for security and to work around some issues with incremental builds seen in continuous integration. But now in a position to seriously consider incremental nightlies as well.
 * Discussion on installing directly on CVMFS: Is an issue with relocatability, need to have consistent mount points, and of course a writable CVMFS repository. Currently binaries local to build machine, packaged, then uploaded to EOS.
 * Nexus: can store binary artifacts, then can check existence of required binary when/if needed later. Tool to be investigated.
@@ -58,7 +58,7 @@ layout: default
   low level ABIs.
 * Containers main unit of distribution is an filesystem, image of which is sequence
   of package manager and other operations. Containers interface with each other via
-  abstract file/REST/data server/message queuese
+  abstract file/REST/data server/message queues.
 * Good fit in HEP: global distribution of a complex stack that uses significant OS component to a wide range of systems that we don’t manage like the Grid, HPC user laptops.
 * User developed analysis software has different requirements - often a mix between stages inside release, own code that might require specific directory structure.
   Physics reproducibility is important.
@@ -66,7 +66,7 @@ layout: default
   * "Fat": Completely self-contained, local on disk, no network or local cvmfs install needed. But large (10GB+).
   * "Thin": Only provide OS, domain software from host install of CVMFS - needs network, and no immediate knowledge of what bits in CVMFS are used.
 * Build both as part of nightlies for offline and analysis releases, distributed via Docker Hub.
-* Work on CVMFS Graph Driver - “Fat” Image, can be used directly, but also deployed over CVMFS. Docker can then just pull the bits its needs.
+* Work on CVMFS Graph Driver - “Fat” Image, can be used directly, but also deployed over CVMFS. Docker can then just pull the bits it needs.
 * In use for local development, especially on non-supported platforms.
 * In use for CI - easy integration on common platforms
 * Also for grid deployment - using Singularity as container runtime. HPC may lack networked filesystems like CVMFS, but can support containers


### PR DESCRIPTION
This adds the post for minutes of the Packaging WG meeting of 29/11/17, and also proposes a slight change to the layout of the activities page for the group.

In the latter case, no longer list meeting explicitly, but highlight the Indico site.