### PR TITLE
Update website for CWP Roadmap release

### DIFF
--- a/_activities/cwp.md
+++ b/_activities/cwp.md
@@ -1,181 +1,58 @@
 ---
 title: "Community White Paper"
-author: "Peter Elmer"
+author: "Graeme Stewart"
 layout: default
 redirect_from:
   - /cwp.html
   - /workinggroups/2016/07/06/communitywhitepaper.html
 ---
 
-# Community White Paper (CWP) 
+# A Roadmap for HEP Software and Computing R&D for the 2020s
 
-## A Roadmap for HEP Software and Computing R&D for the 2020s
+In 2017 the HEP Software Foundation produced a 
+[roadmap white paper](https://arxiv.org/abs/1712.06982){:target="_cwp_roadmap_arxiv"} on the
+software and computing challenges that will be faced during the next decade.
 
-Realizing the physics programs of the planned and/or upgraded HEP experiments 
-over the next 10 years will require the HEP community to address a number of 
-challenges in the area of software and computing. It is expected that
-the computing models will need to evolve and a significant "software 
-upgrade" is required to prepare.
-In order to identify and prioritize the software research and development 
-investments required, we are now beginning a community planning process. The 
-aim
-is to produce a Community White Paper 
-(CWP) which will describe the community strategy and a roadmap for 
-software and computing R&D in HEP for the 2020s. This activity is organised under 
-the umbrella of the HSF. The LHC experiments and HSF have been 
-specifically [charged by the WLCG project](/assets/CWP-Charge-HSF.pdf) and
-we are reaching out to other HEP experiments around the world to participate.
+**The CWP Roadmap can still be signed by members of the community who endorse
+it.** Please use contact the 
+[CWP Ghost Writers](mailto:hsf-cwp-ghost-writers@googlegroups.com?subject=CWP Signature) to add your name.
+We very much encourage you to do this, to show the breadth of the community's support
+for the roadmap.
 
-## Final Roadmap Paper
+## Community White Paper Reports
 
-The second draft of the CWP, the 
-[Roadmap for HEP Software and Computing R&D for the 2020s](https://docs.google.com/document/d/1RIcnj7DBNOoQ1DT45WCGFboS0tCDeJcvAi2xjPv_UVQ){:target="_cwp_roadmap"} 
-report (also available as a 
-[pdf]({{site.docs.url}}/CWP/papers/roadmap/HSF-Community-White-Paper-v0.2.pdf)) has been released to the community on November 17. Comments were received
-until December 4 and the final paper is now being prepared. It will be released on December 15.
+The roadmap summarised reports from fourteen working groups who studied the challenges in their
+sub-domains. All of the reports produced during the Community White Paper process are listed below.
 
-We have also started to **collect signatures for the CWP** with the aim of having it signed by everyone in the HEP community who gives it their broad support.
-If, based on the second (almost final) draft, you are 
-**willing to be one of the signatories**, please add your name to the dedicated 
-[Google Doc](https://docs.google.com/document/d/1tBXwlNnQsxxZA3gVS1_KSpa8wRXGyk250EIsJwJ2T34/edit#){:target="_cwp_signatories"} (or contact the 
-[CWP Editorial Board](mailto:hsf-cwp-ed-board@googlegroups.com)), if possible before December 14.
+{:.table .table-hover .table-condensed .table-striped}
+| *Paper* | *Report Number* | *Link* |
+| ------- | --------------- | ------ |
+| CWP Roadmap | HSF-CWP-2017-01 | [arXiv](https://arxiv.org/abs/1712.06982){:target="_cwp_roadmap_arxiv"} |
+| Careers & Training	 | HSF-CWP-2017-02	| [ShareLaTeX](https://www.sharelatex.com/project/595500273c5204ff35dfdcf9){:target="_cwp_cst"} | 
+| Conditions Data | HSF-CWP-2017-03	| [Google Doc](https://docs.google.com/document/d/1yTcw51TOc68DCZQ4AO7o1hBdkPbN5l52ysJgJXNnJl8/edit){:target="_cwp_cdb"} |
+| Data Organisation, Management and Access | HSF-CWP-2017-04	| [Google Doc](https://docs.google.com/document/d/1_YKGs8waBidpS8akmjxEVjV00DThINbJAuVelzk2uHg/edit){:target="_cwp_doma"} |
+| Data Analysis and Interpretation | HSF-CWP-2017-05	| [Dropbox](http://tinyurl.com/yaf32pks){:target="_cwp_analysis"} |
+| Data and Software Preservation | HSF-CWP-2017-06 | [Google Doc](https://docs.google.com/document/d/17309oyniwK01qvJgDPrBsLw_-jqRgvkvWZi5lLmQISI/edit){:target="_cwp_dsp"} |
+| Detector Simulation | HSF-CWP-2017-07	| [Summary Google Doc](https://docs.google.com/document/d/15dyg1H5FMkbAWJf8WC6cXa6X62L1Q9AXLJuRGD-FR00/edit?usp=sharing){:target="_cwp_simsum"}; [Google Doc](https://docs.google.com/document/d/1Qm8btmDti1dcu5G2FMez3J6FLyzv0k6fag0clD25JSo/edit?ts=5977c5fc){:target="_cwp_sim"} |
+| Event/Data Processing Frameworks | HSF-CWP-2017-08	| [Google Doc](https://docs.google.com/document/d/1DYEHGgB3fanhpYRDJblE9NicX0OK7BNsjTCrq7gY-sU/edit?usp=sharing){:target="_cwp_fwk"} |
+| Facilities and Distributed Computing | HSF-CWP-2017-09	| [Google Doc](https://docs.google.com/document/d/1dm5vxejQrKZ19Y-pBLaqBcI_Z_yEN6S0N3Z4UonoTn8/edit?usp=sharing){:target="_cwp_fdc"} |
+| Machine Learning | HSF-CWP-2017-10	| [ShareLaTeX](https://www.sharelatex.com/project/593a919f0f690d906afbfc76){:target="_cwp_ml"} |
+| Physics Generators | HSF-CWP-2017-11 | [Overleaf](https://www.overleaf.com/read/wyyybnvxyfyn){:target="_cwp_ph"} |
+| Security | HSF-CWP-2017-12	 | See section 3.13 of [roadmap](https://arxiv.org/abs/1712.06982){:target="_cwp_roadmap_arxiv"} |
+| Software Development, Deployment and Validation | HSF-CWP-2017-13 | [Google Doc](https://docs.google.com/document/d/1EtvAda2bZw5AHjhcqK-2T7bDlvznypZIWL-Bw3X6BWQ/edit?usp=sharing){:target="_cwp_sddp"} |
+| Software Trigger and Event Reconstruction | HSF-CWP-2017-14	| [Summary Google Doc](https://docs.google.com/document/d/1f1rOFwqRh7FhSB2VXf5hM14r5wHdkIXo3AdBcYkC1qk){:target="_cwp_stersum"}; [Google Doc](https://docs.google.com/document/d/1QRO8RA488fwfSg5CSjmvm16-pZpGApSA0l666g_mS_0/edit#){:target="_cwp_ster"} |
+| Visualisation | HSF-CWP-2017-15 | [Google Doc](https://docs.google.com/document/d/1dtE2DEdYCWzPaEy_twgSCFdmGxphXMjMcOV0yjI4AKc/edit){:target="_cwp_visu"} |
 
-*Note: if you need to look at the first draft, released on October 20, it is still available as a
-[Google Docs](https://docs.google.com/document/d/1rcPIJQc3LNAh5tjHKjfuq80StrMO5ksiLwhDlJzeg9U/edit?usp=sharing){:target="_cwp_roadmap"} 
-or as a [PDF]({{site.docs.url}}/CWP/papers/roadmap/HSF-Community-White-Paper-v0.1-linenumbers.pdf).*
 
-### Talks
+## Talks
 
-This is a list of recent talks about the CWP which were given by various HSF members:
+This is a list of talks about the CWP Roadmap that were given by various HSF members:
 
 * 2017-11-28 [Presentation](https://indico.desy.de/indico/event/18681/session/8/contribution/114/material/slides/0.pdf) at the [11th Terascale Alliance Workshop](https://indico.desy.de/indico/event/18681/) by Benedikt Hegner.
 * 2017-10-29 [Presentation](https://indico.cern.ch/event/663273/contributions/2708178/attachments/1545100/2431717/HSF-CWP-Roadmap.pdf) on the CWP Roadmap at 
   the [3rd Scientific Computing Forum](https://indico.cern.ch/event/663273/) by Graeme Stewart.
 
-## Editorial Team
+## History
 
-  * Predrag Buncic (CERN) - Alice contact
-  * Simone Campana (CERN) - ATLAS contact
-  * Peter Elmer (Princeton)
-  * John Harvey (CERN)
-  * Benedikt Hegner (CERN)
-  * Frank Gaede (DESY) - Linear Collider contact
-  * Maria Girone (CERN Openlab)
-  * Roger Jones (Lancaster University) - UK contact
-  * Michel Jouvin (LAL Orsay)
-  * Thomas Kuhr (LMU) - Belle II contact
-  * David Lange (Princeton University)
-  * Rob Kutschke (FNAL) - FNAL experiments contact
-  * Dario Menasce (INFN-Milano) - INFN contact
-  * Mark Neubauer (U.Illinois Urbana-Champaign)
-  * Eduardo Rodrigues (U.Cincinnati)
-  * Stefan Roiser (CERN) - LHCb contact
-  * Liz Sexton-Kennedy (FNAL) - CMS contact
-  * Mike Sokoloff (U.Cincinnati)
-  * Graeme Stewart (CERN, HSF)
-  * Jean-Roch Vlimant (Caltech)
-
-## Draft WG white papers and status
-
-  * Careers, Staffing and Training WG
-    * Draft WG white paper: [ShareLaTeX](https://www.sharelatex.com/project/595500273c5204ff35dfdcf9){:target="_cwp_cst"} - **available for review**
-  * Conditions Database WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1yTcw51TOc68DCZQ4AO7o1hBdkPbN5l52ysJgJXNnJl8/edit){:target="_cwp_cdb"} - **available for review**
-  * Data Organization, Management and Access WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1_YKGs8waBidpS8akmjxEVjV00DThINbJAuVelzk2uHg/edit){:target="_cwp_doma"} - **available for review**
-  * Data Analysis and Interpretation WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/13ediEyaP1QGF-esZOXUH3SNShJFsqa2f6hVmEukJv_c/edit){:target="_cwp_dai"} - **available for review**
-  * Data and Software Preservation WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/17309oyniwK01qvJgDPrBsLw_-jqRgvkvWZi5lLmQISI/edit){:target="_cwp_dsp"} - **available for review**
-  * Detector Simulation WG
-	* Executive summary [paper available](https://docs.google.com/document/d/15dyg1H5FMkbAWJf8WC6cXa6X62L1Q9AXLJuRGD-FR00/edit?usp=sharing){:target="_cwp_simsum"} - **available for review**
-	* Draft WG white paper: [google doc](https://docs.google.com/document/d/1Qm8btmDti1dcu5G2FMez3J6FLyzv0k6fag0clD25JSo/edit?ts=5977c5fc){:target="_cwp_sim"} - **available for review**
-  * Event/Data Processing Frameworks WG 
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1DYEHGgB3fanhpYRDJblE9NicX0OK7BNsjTCrq7gY-sU/edit?usp=sharing){:target="_cwp_epf"} - fairly complete, needs executive summary
-  * Facilities, and Distributed Computing WG 
-	* Draft WG white paper: [google doc](https://docs.google.com/document/d/1dm5vxejQrKZ19Y-pBLaqBcI_Z_yEN6S0N3Z4UonoTn8/edit?usp=sharing){:target="_cwp_fdc"} - **available for review**
-  * Machine Learning WG
-    * Draft WG white paper: [sharelatex](https://www.sharelatex.com/project/593a919f0f690d906afbfc76){:target="_cwp_ml"} - submitted for wider community review
-  * Physics Generators WG
-    * Draft WG white paper: [Overleaf](https://www.overleaf.com/read/wyyybnvxyfyn){:target="_cwp_ph"} - **available for review**  
-  * Software Development, Deployment and Validation/Verification WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1EtvAda2bZw5AHjhcqK-2T7bDlvznypZIWL-Bw3X6BWQ/edit?usp=sharing){:target="_cwp_sddp"} - finshed, **available for review**
-  * Software Trigger and Event Reconstruction WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1QRO8RA488fwfSg5CSjmvm16-pZpGApSA0l666g_mS_0/edit#){:target="_cwp_ster"} - **available for review** (Frozen version: [pdf](https://drive.google.com/open?id=0B8p0qzoMmbwbRFF4RmFtamlCaWs))
-    * Draft WG executive summary: [google doc](https://docs.google.com/document/d/1f1rOFwqRh7FhSB2VXf5hM14r5wHdkIXo3AdBcYkC1qk){:target="_cwp_stersum"} - **available for review** (Frozen version: [pdf](https://drive.google.com/file/d/0B8p0qzoMmbwbdGRZV0lTUDZHZ3c/view?usp=sharing))   
-  * Visualization WG
-    * Draft WG white paper: [google doc](https://docs.google.com/document/d/1dtE2DEdYCWzPaEy_twgSCFdmGxphXMjMcOV0yjI4AKc/edit#heading=h.aywciqdbmlzq){:target="_cwp_visu"} - still writing
-    
-### Archive
-
-We keep some [snapshots](/cwp/cwp-papers.html) of Working Group Papers that are useful
-for reference or if Google Docs are not available.
-
-## Working Groups
-
-  The list of CWP working groups, their charges and working documents is maintained on a [dedicated working group page](/cwp/cwp-working-groups.html).
-
-## Main CWP Events
-
-After a preparatory phase during Fall 2016, the CWP process was launched in January, 2017.
-A series of workshops or events related to the CWP have taken place:
-
-  * 23-27 Jan, 2017 - HSF CWP workshop at SDSC/UCSD
-    * [Indico page](http://indico.cern.ch/event/570249/)
-  * 9 Mar, 2017 - Software Triggers and Event Reconstruction WG meeting
-    * A CWP session at the [Connecting The Dots workshop](https://ctdwit2017.lal.in2p3.fr)
-    * [Indico page](https://indico.cern.ch/event/614111/)
-  * 20-22 Mar, 2017 - IML Topical Machine Learning Workshop
-    * *CERN*
-    * The workshop includes a CWP session on Machine Learning
-    * [Indico page](https://indico.cern.ch/event/595059)
-  * 28-30 Mar, 2017 - CWP Visualization Workshop
-    * *CERN (and Vidyo)*
-    * [Indico page](https://indico.cern.ch/event/617054/)
-  * 8-12 May, 2017 - DS@HEP 2017 (Data Science in High Energy Physics)
-    * *FNAL*
-    * [Indico page](https://indico.fnal.gov/conferenceDisplay.py?confId=13497)
-  * 22-24 May, 2017 - HEP Analysis Ecosystem Retreat
-    * *Amsterdam*
-    * [Indico page](http://indico.cern.ch/event/613842/)
-    * [Workshop proposal](https://docs.google.com/document/d/1aAGCj_y9in_I-c9yYJ-XX3Qurf0PXH4tFoYmvuCY5tk/edit#heading=h.9h0v0hyue6zf)
-  * 5-6 Jun, 2017 - CWP Event Processing Frameworks Workshop
-    * *FNAL*
-    * The workshop is just prior to the FNAL 50th Anniversary and User Meeting
-    * [Indico page](https://indico.fnal.gov/conferenceDisplay.py?confId=14186)
-  * 26-30 Jun, 2017 - HEP Software Foundation Workshop
-    * *LAPP (Annecy)*
-    * [Indico page](https://indico.cern.ch/event/613093/)
-    * Every WG agreed to start the process of finalising their WG documents
-  * 21-25 Aug, 2017 - ACAT 2017 (International Workshop on Advanced Computing and Analysis Techniques in Physics Research)
-    * *University of Washington (Seattle)*
-    * [Indico page](https://indico.cern.ch/event/567550/)
-
-## Communication
-
-To join the CWP process and get information about its progress, please join the [hsf-community-white-paper](https://groups.google.com/forum/#!forum/hsf-community-white-paper) Google group (no Google account is required, you can register by sending an email to [hsf-community-white-paper+subscribe@googlegroups.com](mailto:hsf-community-white-paper+subscribe@googlegroups.com)). Subscribing to this group with a Google account is required if you want to be able to contribute to CWP documents hosted in Google Docs. Individual working groups may also have their own list or google group (see below).
-
-## CWP Process
-
-The CWP process has involved a number of workshops between January and Summer 2017. As part of the process members of the community have been encouraged to write white papers to describe their ideas on the various topics. White papers can be submitted by anyone: individuals, groups of individuals, experiments, institutions, etc.
-
-We maintain a [list of contributed CWP whitepapers](http://hepsoftwarefoundation.org/cwp-whitepapers.html).
-
-If you have a white paper which you would like to contribute to the CWP process, please submit it (in pdf or link form, e.g. in the arXiv) to hsf-cwp-white-paper-submission@googlegroups.com and it will add be added to this list.
-
-Some guidance and suggestions for WGs can be found here:
-
-  * [Guidance for WGs at HSF workshop at SDSC](http://hepsoftwarefoundation.org/cwp/cwp-wg-guidance-sdsc.html)
-
-## Other notes
-
-The timeline for producing a CWP by summer, 2017, corresponds roughly to
-the plan for [CERN openlab](http://openlab.cern/) to produce a similar white paper describing the plans for their next phase beginning in January, 2018. We expect that the CWP process and CERN openlab planning processes will be synergistic.
-
-## Related links
-
-- [CWP presentation @CHEP2016](https://indico.cern.ch/event/505613/contributions/2323238/attachments/1352966/2043354/20161011-chep-cwp-plenary.pdf)
-- [Initial HSF CWP Google Doc](https://docs.google.com/document/d/140HEAxD0u_XAUKYrCR3SahxyHxFfJ_YOFJpsNubMiC8/edit) - this document is now deprecated and we are moving the contents to this HSF webpage 
-- [US NSF S2I2 Conceptualization Project](http://s2i2-hep.org/) and [Google Group](https://groups.google.com/forum/#!forum/s2i2-hep)
-
- 
+A [historical page](../cwp/cwp-history.html) is maintained that describes in more detail
+the process that the community took to arrive at the final outcome. 

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -12,8 +12,10 @@ layout: default
           </div>
           <div class="col-md-8">
             <p class="lead">
-The HEP Software Foundation (HSF) facilitates coordination and common efforts in high energy physics (HEP) software and computing internationally.
-           </p>
+The HEP Software Foundation facilitates cooperation and 
+<a href="{{site.baseurl}}/activities/cwp.html">common efforts</a> 
+in High Energy Physics software and computing internationally.
+</p>
       </div>
       </div>
 
@@ -21,9 +23,11 @@ The HEP Software Foundation (HSF) facilitates coordination and common efforts in
 
 <!-- Important announcements from announcements/_posts -->
 <div>
-The HSF is guiding a community process to develop a consensus roadmap for HEP Software and Computing R&amp;D for the 2020s.
-More information can be found on the
-<a href="{{site.baseurl}}/activities/cwp.html">Community White Paper (CWP)</a> page on the HSF site.
+<p class="lead">
+The HSF has now submitted the 
+<a href="https://arxiv.org/abs/1712.06982" target="_cwp_roadmap_arxiv">final roadmap paper</a> from the
+<a href="{{site.baseurl}}/activities/cwp.html">Community White Paper</a> exercise.
+</p>
 </div>
 <hr>
   {% assign sitedate = site.time | date: "%Y-%m-%d"   %}

--- a/announcements/_posts/2017-12-20-hsf-wlcg-naples.md
+++ b/announcements/_posts/2017-12-20-hsf-wlcg-naples.md
@@ -1,0 +1,9 @@
+---
+title:  Joint HSF WLCG Workshop 26-29 March, 2018
+author: Graeme Stewart
+layout: newsletter
+symbol: glyphicon-calendar
+link: events/2017/12/20/hsf-wlcg-naples.html
+until: 2018-03-26
+---
+Joint HSF WLCG workshop in Naples, 26-29 March 2018.

--- a/cwp/cwp-history.md
+++ b/cwp/cwp-history.md
@@ -1,0 +1,136 @@
+---
+title: "Community White Paper"
+author: "Peter Elmer"
+layout: default
+---
+
+# Community White Paper (CWP) 
+
+This page gives more detail about the process that gave rise
+to the HSF's [Community White Paper Roadmap](../activities/cwp.html)
+for HEP Software and Computing R&D for the 2020s.
+
+It is kept for historical interest and to preserve intermediate documents
+about exercise.
+
+----
+
+## A Roadmap for HEP Software and Computing R&D for the 2020s
+
+Realizing the physics programs of the planned and/or upgraded HEP experiments 
+over the next 10 years requires the HEP community to address a number of 
+challenges in the area of software and computing. It is expected that
+the computing models will need to evolve and a significant "software 
+upgrade" is required.
+In order to identify and prioritize the software research and development 
+investments required, we embarked on a community planning process. The 
+aim
+was to produce a Community White Paper 
+(CWP) which would describe the community strategy and a roadmap for 
+software and computing R&D in HEP for the 2020s. This activity was organised under 
+the umbrella of the HSF. The LHC experiments and HSF were 
+specifically [charged by the WLCG project](/assets/CWP-Charge-HSF.pdf) and
+reached out to other HEP experiments around the world to participate.
+
+## Final Roadmap Paper
+
+The [final version](https://arxiv.org/abs/1712.06982){:target="_cwp_roadmap_arxiv"}
+of the CWP Roadmap was submitted to arXiv on 15 December 2017.
+It was accepted on 18 December.
+
+**The roadmap can still be endorsed by the community** and minor updates will be done
+to expand the author list and or to correct any errors found. Please contact the 
+[CWP Ghost Writers](mailto:hsf-cwp-ghost-writers@googlegroups.com?subject=CWP Signature).
+*We very much encourage you to do this, to show the breadth of the community's support
+for the roadmap.*
+
+The second draft of the CWP, the 
+[Roadmap for HEP Software and Computing R&D for the 2020s](https://docs.google.com/document/d/1RIcnj7DBNOoQ1DT45WCGFboS0tCDeJcvAi2xjPv_UVQ){:target="_cwp_roadmap"} 
+report (also available as a 
+[pdf]({{site.docs.url}}/CWP/papers/roadmap/HSF-Community-White-Paper-v0.2.pdf)) 
+was released to the community on November 17.
+
+The first draft was released on October 20, it is still available as a
+[Google Docs](https://docs.google.com/document/d/1rcPIJQc3LNAh5tjHKjfuq80StrMO5ksiLwhDlJzeg9U/edit?usp=sharing){:target="_cwp_roadmap"} 
+or as a [PDF]({{site.docs.url}}/CWP/papers/roadmap/HSF-Community-White-Paper-v0.1-linenumbers.pdf).
+
+## Editorial Team
+
+The Editorial Board, which helped to prepare the final version of the roadmap, was:
+
+  * Predrag Buncic (CERN) - Alice contact
+  * Simone Campana (CERN) - ATLAS contact
+  * Peter Elmer (Princeton)
+  * John Harvey (CERN)
+  * Benedikt Hegner (CERN)
+  * Frank Gaede (DESY) - Linear Collider contact
+  * Maria Girone (CERN Openlab)
+  * Roger Jones (Lancaster University) - UK contact
+  * Michel Jouvin (LAL Orsay)
+  * Thomas Kuhr (LMU) - Belle II contact
+  * David Lange (Princeton University)
+  * Rob Kutschke (FNAL) - FNAL experiments contact
+  * Dario Menasce (INFN-Milano) - INFN contact
+  * Mark Neubauer (U.Illinois Urbana-Champaign)
+  * Eduardo Rodrigues (U.Cincinnati)
+  * Stefan Roiser (CERN) - LHCb contact
+  * Liz Sexton-Kennedy (FNAL) - CMS contact
+  * Mike Sokoloff (U.Cincinnati)
+  * Graeme Stewart (CERN, HSF)
+  * Jean-Roch Vlimant (Caltech)
+
+## Working Groups
+
+  The list of CWP working groups, their charges and working documents was maintained on a [dedicated working group page](/cwp/cwp-working-groups.html).
+
+## Main CWP Events
+
+The following series of workshops or events related to the CWP took place:
+
+  * 23-27 Jan, 2017 - HSF CWP workshop at SDSC/UCSD
+    * [Indico page](http://indico.cern.ch/event/570249/)
+  * 9 Mar, 2017 - Software Triggers and Event Reconstruction WG meeting
+    * A CWP session at the [Connecting The Dots workshop](https://ctdwit2017.lal.in2p3.fr)
+    * [Indico page](https://indico.cern.ch/event/614111/)
+  * 20-22 Mar, 2017 - IML Topical Machine Learning Workshop
+    * *CERN*
+    * The workshop includes a CWP session on Machine Learning
+    * [Indico page](https://indico.cern.ch/event/595059)
+  * 28-30 Mar, 2017 - CWP Visualization Workshop
+    * *CERN (and Vidyo)*
+    * [Indico page](https://indico.cern.ch/event/617054/)
+  * 8-12 May, 2017 - DS@HEP 2017 (Data Science in High Energy Physics)
+    * *FNAL*
+    * [Indico page](https://indico.fnal.gov/conferenceDisplay.py?confId=13497)
+  * 22-24 May, 2017 - HEP Analysis Ecosystem Retreat
+    * *Amsterdam*
+    * [Indico page](http://indico.cern.ch/event/613842/)
+    * [Workshop proposal](https://docs.google.com/document/d/1aAGCj_y9in_I-c9yYJ-XX3Qurf0PXH4tFoYmvuCY5tk/edit#heading=h.9h0v0hyue6zf)
+  * 5-6 Jun, 2017 - CWP Event Processing Frameworks Workshop
+    * *FNAL*
+    * The workshop is just prior to the FNAL 50th Anniversary and User Meeting
+    * [Indico page](https://indico.fnal.gov/conferenceDisplay.py?confId=14186)
+  * 26-30 Jun, 2017 - HEP Software Foundation Workshop
+    * *LAPP (Annecy)*
+    * [Indico page](https://indico.cern.ch/event/613093/)
+    * Every WG agreed to start the process of finalising their WG documents
+  * 21-25 Aug, 2017 - ACAT 2017 (International Workshop on Advanced Computing and Analysis Techniques in Physics Research)
+    * *University of Washington (Seattle)*
+    * [Indico page](https://indico.cern.ch/event/567550/)
+
+## CWP Process
+
+The CWP process involved a number of workshops between January and Summer 2017. As part of the process members of the community were encouraged to write white papers to describe their ideas on the various topics. White papers could be submitted by anyone: individuals, groups of individuals, experiments, institutions, etc.
+
+There is a [list of the contributed CWP whitepapers](http://hepsoftwarefoundation.org/cwp-whitepapers.html).
+
+Some guidance and suggestions for WGs was orignally given here: [Guidance for WGs at HSF workshop at SDSC](http://hepsoftwarefoundation.org/cwp/cwp-wg-guidance-sdsc.html)
+
+
+## Related links
+
+- [CWP presentation @CHEP2016](https://indico.cern.ch/event/505613/contributions/2323238/attachments/1352966/2043354/20161011-chep-cwp-plenary.pdf)
+- [Initial HSF CWP Google Doc](https://docs.google.com/document/d/140HEAxD0u_XAUKYrCR3SahxyHxFfJ_YOFJpsNubMiC8/edit).
+- [US NSF S2I2 Conceptualization Project](http://s2i2-hep.org/) and [Google Group](https://groups.google.com/forum/#!forum/s2i2-hep)
+
+ 

--- a/events/_posts/2017-12-20-hsf-wlcg-naples.md
+++ b/events/_posts/2017-12-20-hsf-wlcg-naples.md
@@ -1,0 +1,29 @@
+---
+title:  HEP Software Foundation WLCG Workshop, Naples, March 26-29 2018
+author: Graeme Stewart
+layout: event
+startdate: 2018-03-26
+---
+
+The HSF and WLCG will hold a joint workshop that addresses the challenges
+identified by the [Community White Paper](/activities/cwp.html)
+process. The workshop will focus on the long term evolution of 
+software and computing in HEP, particularly oriented towards
+the High Luminosity LHC, the Intensity Frontier and 
+new experiments in the future.
+
+The preliminary agenda and further details, including travel and hotel 
+information are now available on the [indico page](https://indico.cern.ch/event/658060/){:target="_naples_ws"}.
+
+There will be common plenary sessions, focused on the main 
+challenges for HEP described in the CWP, and parallel sessions to 
+discuss and define concrete R&D projects.
+
+There also will be ample scope for additional community driven topics. 
+Please [contact us](mailto:WLCG-HSF-Workshop-2018-organisation@cern.ch)
+if you are interested in using one of the reserved slots and to organise 
+a session dedicated to a particular topic.
+
+Registration will open at the end of January as we are still exploring 
+sponsorship for the workshop. We will send another email with updated 
+information by mid-January.


### PR DESCRIPTION
Fairly substantial update:
- Front page was updated to link to arXiv document and new CWP "result"
  page; announcement of joint Naples workshop
- Naples workshop added as an upcoming event
- Main CWP page has been rewritten to be a summary of the CWP outcome
- Old CWP page has been moved to a history page, rewritten to be in the past
  tense and only relevant information kept