### PR TITLE
Material for PyHEP series of workshops

### DIFF
--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -1,5 +1,5 @@
 ---
-title: PyHEP - "Python in HEP" Series of Workshops
+title: PyHEP Workshops
 author: "Eduardo Rodrigues"
 layout: default
 ---

--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -40,6 +40,6 @@ Jeff Templon - Nikhef (Co-chair)
 ## Workshops
 
 {:.table .table-hover .table-condensed .table-striped}
-| *Workshop* | *Location*          | *Date*               | *Agenda link* |
-| ---------- | ------------------- | ---------------------| ------------- |
-| PyHEP 2018 | Sofia, Bulgaria     | July 7-8, 2018       | |
+| *Workshop* | *Location*          | *Date*               | *Agenda link*                                                                 |
+| ---------- | ------------------- | ---------------------| ----------------------------------------------------------------------------- |
+| PyHEP 2018 | Sofia, Bulgaria     | July 7-8, 2018       | [Indico](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"}   |

--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -15,7 +15,7 @@ with the aim to provide an environment to discuss and promote the usage of Pytho
 The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, on 7-8 July 2018, just before the start of the [CHEP 2018 conference](http://chep2018.org/). It will focus on a review of where and how Python is used in our community, and what the future will hold.
 The workshop will be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.
 
-The agenda will be composed of plenary sessions dedicated to the following topics:
+The [agenda](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"} will be composed of plenary sessions dedicated to the following topics:
 
 1. Historical perspective and overview
 2. PyROOT and Python bindings

--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -1,0 +1,36 @@
+---
+title: PyHEP - "Python in HEP" Series of Workshops
+author: "Eduardo Rodrigues"
+layout: default
+redirect_from:
+  - /pyhep.html
+---
+
+# PyHEP "Python in HEP" Series of Workshops
+
+The PyHEP workshops are a new series of workshops initiated and supported by the HSF
+with the aim to provide an environment to discuss and promote the usage of Python in the HEP community at large.
+
+The first workshop, PyHEP 2018, will be held as a pre-CHEP event in Sofia, Bulgaria, the weekend just before the start of the CHEP2018 conference, i.e. on July 7-8 2018. It will focus on the review of where and how Python is used in our community. The workshop will also be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF Community White Paper (https://arxiv.org/abs/1712.06982). There will be ample time for discussion.
+
+There agenda will be composed (exclusively) of plenary sessions dedicated to the following topics:
+1) Historical perspective and overview
+2) PyROOT and Python bindings
+3) HEP python software ecosystem
+4) Installation and distribution
+5) Analysis frameworks
+6) Python 2 versus 3
+7) Open discussion on education and training
+
+Note that there won't be any training session nor hackaton in this first workshop.
+Some level of (brief) training will come in small bites in the various presentations,
+which will try and be educative, not just informative, with well-defined examples relevant to the topics under discussion.
+In a future PyHEP workshop training and/or hackathons will be considered in connection with the HSF planning as far as cross-experiment training is concerned.
+
+
+## Workshops
+
+{:.table .table-hover .table-condensed .table-striped}
+| *Workshop* | *Location*          | *Agenda link* |
+| ------- | ---------------------- | ------------- |
+| PyHEP 2018 | Sofia, Bulgaria     | |

--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -1,9 +1,5 @@
 ---
 title: PyHEP - "Python in HEP" Series of Workshops
-author: "Eduardo Rodrigues"
-layout: default
-redirect_from:
-  - /pyhep.html
 ---
 
 # PyHEP "Python in HEP" Series of Workshops
@@ -14,9 +10,10 @@ with the aim to provide an environment to discuss and promote the usage of Pytho
 
 ## PyHEP 2018
 
-The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, the weekend just before the start of the [CHEP 2018 conference](http://chep2018.org/), i.e. on July 7-8 2018. It will focus on the review of where and how Python is used in our community. The workshop will also be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.
+The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, on 7-8 July 2018, just before the start of the [CHEP 2018 conference](http://chep2018.org/). It will focus on a review of where and how Python is used in our community, and what the future will hold.
+The workshop will be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.
 
-The agenda will be composed (exclusively) of plenary sessions dedicated to the following topics:
+The agenda will be composed of plenary sessions dedicated to the following topics:
 
 1. Historical perspective and overview
 2. PyROOT and Python bindings
@@ -26,16 +23,16 @@ The agenda will be composed (exclusively) of plenary sessions dedicated to the f
 6. Python 2 versus 3
 7. Open discussion on education and training
 
-Note that there won't be any training session nor hackaton in this first workshop.
-Some level of (brief) training will come in small bites in the various presentations,
+There won't be any training sessions or hackathons in this first workshop,
+but some level of tuition will come in small bites in the various presentations,
 which will try and be educative, not just informative, with well-defined examples relevant to the topics under discussion.
-In a future PyHEP workshop training and/or hackathons will be considered in connection with the HSF planning as far as cross-experiment training is concerned.
+One of the goals of this PyHEP workshop will be to identify training workshops or hackathons the community would like to have in the future.
 
 ### Organising Committee
 
-Eduardo Rodrigues, University of Cincinnati (Chair)<br>
-Graeme Stewart, CERN-HSF<br>
-Jeff Templon, Nikhef (Co-chair)
+Eduardo Rodrigues - University of Cincinnati (Chair)<br>
+Graeme Stewart - CERN-HSF<br>
+Jeff Templon - Nikhef (Co-chair)
 
 
 ## Workshops

--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -8,29 +8,39 @@ redirect_from:
 
 # PyHEP "Python in HEP" Series of Workshops
 
-The PyHEP workshops are a new series of workshops initiated and supported by the HSF
+The **PyHEP workshops** are a new series of workshops initiated and supported by the HSF
 with the aim to provide an environment to discuss and promote the usage of Python in the HEP community at large.
 
-The first workshop, PyHEP 2018, will be held as a pre-CHEP event in Sofia, Bulgaria, the weekend just before the start of the CHEP2018 conference, i.e. on July 7-8 2018. It will focus on the review of where and how Python is used in our community. The workshop will also be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF Community White Paper (https://arxiv.org/abs/1712.06982). There will be ample time for discussion.
 
-There agenda will be composed (exclusively) of plenary sessions dedicated to the following topics:
-1) Historical perspective and overview
-2) PyROOT and Python bindings
-3) HEP python software ecosystem
-4) Installation and distribution
-5) Analysis frameworks
-6) Python 2 versus 3
-7) Open discussion on education and training
+## PyHEP 2018
+
+The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, the weekend just before the start of the [CHEP 2018 conference](http://chep2018.org/), i.e. on July 7-8 2018. It will focus on the review of where and how Python is used in our community. The workshop will also be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.
+
+The agenda will be composed (exclusively) of plenary sessions dedicated to the following topics:
+
+1. Historical perspective and overview
+2. PyROOT and Python bindings
+3. HEP python software ecosystem
+4. Distribution and installation
+5. Analysis frameworks
+6. Python 2 versus 3
+7. Open discussion on education and training
 
 Note that there won't be any training session nor hackaton in this first workshop.
 Some level of (brief) training will come in small bites in the various presentations,
 which will try and be educative, not just informative, with well-defined examples relevant to the topics under discussion.
 In a future PyHEP workshop training and/or hackathons will be considered in connection with the HSF planning as far as cross-experiment training is concerned.
 
+### Organising Committee
+
+Eduardo Rodrigues, University of Cincinnati (Chair)<br>
+Graeme Stewart, CERN-HSF<br>
+Jeff Templon, Nikhef (Co-chair)
+
 
 ## Workshops
 
 {:.table .table-hover .table-condensed .table-striped}
-| *Workshop* | *Location*          | *Agenda link* |
-| ------- | ---------------------- | ------------- |
-| PyHEP 2018 | Sofia, Bulgaria     | |
+| *Workshop* | *Location*          | *Date*               | *Agenda link* |
+| ---------- | ------------------- | ---------------------| ------------- |
+| PyHEP 2018 | Sofia, Bulgaria     | July 7-8, 2018       | |

--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -1,5 +1,7 @@
 ---
 title: PyHEP - "Python in HEP" Series of Workshops
+author: "Eduardo Rodrigues"
+layout: default
 ---
 
 # PyHEP "Python in HEP" Series of Workshops

--- a/announcements/_posts/2016-06-04-calendar.md
+++ b/announcements/_posts/2016-06-04-calendar.md
@@ -6,4 +6,4 @@ symbol: glyphicon-pencil
 link: https://calendar.google.com/calendar/embed?src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com&ctz=Europe/Amsterdam
 until: 2016-10-01
 ---
-The HSF prepared a software community calendar, linked  under 'activies' in the menu.
+The HSF prepared a software community calendar, linked  under 'activities' in the menu.

--- a/announcements/_posts/2018-01-15-pyhep2018.md
+++ b/announcements/_posts/2018-01-15-pyhep2018.md
@@ -1,0 +1,9 @@
+---
+title:  PyHEP 2018 Workshop 7-8 July, 2018
+author: Eduardo Rodrigues
+layout: newsletter
+symbol: glyphicon-calendar
+link: events/2018/01/15/pyhep2018.html
+until: 2018-07-08
+---
+PyHEP 2018 "Python in HEP" Workshop, 7-8 July 2018, Sofia (Bulgaria)

--- a/events/_posts/2018-01-15-pyhep2018.md
+++ b/events/_posts/2018-01-15-pyhep2018.md
@@ -7,10 +7,10 @@ startdate: 2018-07-07
 
 We are pleased to announce a new series of workshops initiated and supported by the HEP Software Foundation. The **PyHEP "Python in HEP" workshops** aim to provide an environment to discuss and promote the usage of Python in the HEP community at large.
 
-The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, on 7-8 July 2018, just before the start of the [CHEP 2018 conference](http://chep2018.org/). It will focus on a review of where and how Python is used in our community, and what the future will hold.
-The workshop will be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.
+The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, on 7-8 July 2018, just before the start of the [CHEP 2018 conference](http://chep2018.org/){:target="_chep2018"}. It will focus on a review of where and how Python is used in our community, and what the future will hold.
+The workshop will be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html){:target="_cwp"}. There will be ample time for discussion.
 
-The agenda will be composed of plenary sessions dedicated to the following topics:
+The [agenda](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"} will be composed of plenary sessions dedicated to the following topics:
 
 1. Historical perspective and overview
 2. PyROOT and Python bindings
@@ -20,6 +20,6 @@ The agenda will be composed of plenary sessions dedicated to the following topic
 6. Python 2 versus 3
 7. Open discussion on education and training
 
-The preliminary agenda will soon be available on the workshop indico page linked from the [PyHEP homepage](/activities/pyhep.html){:target="_pyhep"}.
+The preliminary [agenda](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"} will soon be available on the workshop indico page linked from the [PyHEP homepage](/activities/pyhep.html){:target="_pyhep"}.
 
 Further information will be provided via the above link and also as part of the forthcoming CHEP bulletins.

--- a/events/_posts/2018-01-15-pyhep2018.md
+++ b/events/_posts/2018-01-15-pyhep2018.md
@@ -7,9 +7,10 @@ startdate: 2018-07-07
 
 We are pleased to announce a new series of workshops initiated and supported by the HEP Software Foundation. The **PyHEP** "Python in HEP" workshops aim to provide an environment to discuss and promote the usage of Python in the HEP community at large.
 
-The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, the weekend just before the start of the [CHEP 2018 conference](http://chep2018.org/), i.e. on July 7-8 2018. It will focus on the review of where and how Python is used in our community. The workshop will also be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.
+The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, on 7-8 July 2018, just before the start of the [CHEP 2018 conference](http://chep2018.org/). It will focus on a review of where and how Python is used in our community, and what the future will hold.
+The workshop will be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.
 
-The agenda will be composed (exclusively) of plenary sessions dedicated to the following topics:
+The agenda will be composed of plenary sessions dedicated to the following topics:
 
 1. Historical perspective and overview
 2. PyROOT and Python bindings

--- a/events/_posts/2018-01-15-pyhep2018.md
+++ b/events/_posts/2018-01-15-pyhep2018.md
@@ -1,0 +1,24 @@
+---
+title:  PyHEP 2018 "Python in HEP" Workshop, Sofia, July 7-8, 2018
+author: Eduardo Rodrigues
+layout: event
+startdate: 2018-07-07
+---
+
+We are pleased to announce a new series of workshops initiated and supported by the HEP Software Foundation. The **PyHEP** "Python in HEP" workshops aim to provide an environment to discuss and promote the usage of Python in the HEP community at large.
+
+The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, the weekend just before the start of the [CHEP 2018 conference](http://chep2018.org/), i.e. on July 7-8 2018. It will focus on the review of where and how Python is used in our community. The workshop will also be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.
+
+The agenda will be composed (exclusively) of plenary sessions dedicated to the following topics:
+
+1. Historical perspective and overview
+2. PyROOT and Python bindings
+3. HEP python software ecosystem
+4. Distribution and installation
+5. Analysis frameworks
+6. Python 2 versus 3
+7. Open discussion on education and training
+
+The preliminary agenda will soon be available on the workshop indico page linked from the [PyHEP homepage](/activities/pyhep.html){:target="_pyhep"}.
+
+Further information will be provided via the above link and also as part of the forthcoming CHEP bulletins.

--- a/events/_posts/2018-01-15-pyhep2018.md
+++ b/events/_posts/2018-01-15-pyhep2018.md
@@ -5,7 +5,7 @@ layout: event
 startdate: 2018-07-07
 ---
 
-We are pleased to announce a new series of workshops initiated and supported by the HEP Software Foundation. The **PyHEP** "Python in HEP" workshops aim to provide an environment to discuss and promote the usage of Python in the HEP community at large.
+We are pleased to announce a new series of workshops initiated and supported by the HEP Software Foundation. The **PyHEP "Python in HEP" workshops** aim to provide an environment to discuss and promote the usage of Python in the HEP community at large.
 
 The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, on 7-8 July 2018, just before the start of the [CHEP 2018 conference](http://chep2018.org/). It will focus on a review of where and how Python is used in our community, and what the future will hold.
 The workshop will be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.

--- a/organization/team.md
+++ b/organization/team.md
@@ -17,6 +17,7 @@ Currently the activities within the HSF are organized by the *HSF startup team*.
  * Andrew McNab - [Manchester](http://www.hep.manchester.ac.uk)
  * Dario Menasce - [INFN](http://www.mi.infn.it)
  * Mark Neubauer - University of Illinois at Urbana-Champaign
+ * Eduardo Rodrigues - University of Cincinnati
  * Elizabeth Sexton-Kennedy - [FNAL](http://www.fnal.gov)
  * Graeme Stewart - [Glasgow](http://www.gla.ac.uk/schools/physics/research/groups/particlephysicsexperiment/)
  * Craig Tull - [LBNL](http://www.lbl.gov)
@@ -51,7 +52,7 @@ The startup team runs a regular HSF meeting (nominally, and usually, weekly) whi
  * [Challenges in the HEP SW Landscape](https://indico.desy.de/getFile.py/access?contribId=10&resId=0&materialId=1&confId=16073) at the [2016 KET-Meeting](https://indico.desy.de/conferenceDisplay.py?confId=16073), 18 Nov 2016, Benedikt Hegner
  * [Community White Paper: A Roadmap for HEP Software and Computing - Status and Plans](https://indico.cern.ch/event/505613/contributions/2323238/attachments/1352966/2043354/20161011-chep-cwp-plenary.pdf) at [CHEP 2016](http://chep2016.org), 11 Oct 2016, Peter Elmer
  * [Community White Paper: A Roadmap for HEP Software and Computing - Status and Plans](https://indico.cern.ch/event/555063/contributions/2330979/attachments/1350889/2039355/20161009-wlcg-pre-chep-cwp.pdf) at [WLCG Workshop 2016](https://indico.cern.ch/event/555063/), 9 Oct 2016, Peter Elmer
- * [Developing the Roadmap for HL-LHC Software](https://indico.cern.ch/event/524795/contributions/2236597/attachments/1347925/2033396/LHC-Software-Roadmap.pdf) 
+ * [Developing the Roadmap for HL-LHC Software](https://indico.cern.ch/event/524795/contributions/2236597/attachments/1347925/2033396/LHC-Software-Roadmap.pdf)
    at the [ECFA HL-LHC Experiments Workshop](https://indico.cern.ch/event/524795/timetable/), 3-6 Oct 2016, Pere Mato
  * [Community White Paper on HEP software and computing](https://indico.cern.ch/event/536788/contributions/2181213/attachments/1295815/1932438/20160621-wlcg-mb-s2i2-hsf-cwp.pdf) at [WLCG Management Board](https://indico.cern.ch/event/536788/), 21 Jun 2016, Peter Elmer
  * [Community White Paper: a roadmap for the HSF?](https://indico.cern.ch/event/468475/contributions/2176639/attachments/1284555/1909827/20160603-hsf-community-whitepaper-gdb-overview-board.pdf) at [WLCG Overview Board](https://indico.cern.ch/event/468475/), 3 Jun 2016, Peter Elmer


### PR DESCRIPTION
First stab at material describing the workshops. This needs to be online before an announcement of PyHEP 2018 can go out.