### PR TITLE
Technical fixes

### DIFF
--- a/.travis-scripts/url-ignore
+++ b/.travis-scripts/url-ignore
@@ -1,8 +1,11 @@
 # Do not use this file to suppress checks against URLs any more.
-# Instead please add the tag "data-proofer-ignore" to your link,
+# Instead please add the attribute tag "data-proofer-ignore" to your link,
 # see 
 # https://github.com/gjtorikian/html-proofer#ignoring-content
 #
 # To use this technique with a markdown URL, you can use the
 # kramdown extension that adds tags to URLs, e.g.
-# [link text](http://valid.but.unferifiable.com/){:data-proofer-ignore}
+# [link text](http://valid.but.unferifiable.com/){:data-proofer-ignore=""}
+#
+# N.B. Jeykll's kramdown generator changed to ignore plain attributes attached
+# to links, but an using an empty value works just fine. 

--- a/.travis-scripts/url-ignore
+++ b/.travis-scripts/url-ignore
@@ -7,5 +7,5 @@
 # kramdown extension that adds tags to URLs, e.g.
 # [link text](http://valid.but.unferifiable.com/){:data-proofer-ignore=""}
 #
-# N.B. Jeykll's kramdown generator changed to ignore plain attributes attached
-# to links, but an using an empty value works just fine. 
+# N.B. Jekyll's kramdown generator changed to ignore plain attributes attached
+# to links, but using an empty value works just fine. 

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ highlighter: rouge
 markdown: kramdown
 future: true
 exclude: [vendor]
-gems:
+plugins:
   - jekyll-mentions
   - jekyll-sitemap
   - jekyll-redirect-from

--- a/_gsocproposals/proposal_ATLASrucio.md
+++ b/_gsocproposals/proposal_ATLASrucio.md
@@ -48,5 +48,7 @@ A working implementation of the desired new functionalities and fully tested at 
 ## Links
 
 - [Rucio Public Github Mirror](https://github.com/rucio01/rucio)
-- [Rucio Website](http://rucio.cern.ch){:data-proofer-ignore}
+- [Rucio Website](http://rucio.cern.ch){:data-proofer-ignore=""}
 - [Google Cloud Services](https://cloud.google.com/)
+
+<!-- rucio.cern.ch has a broken CA right now --> 

--- a/_gsocproposals/proposal_TMVAmlr.md
+++ b/_gsocproposals/proposal_TMVAmlr.md
@@ -8,7 +8,7 @@ organization:
 ---
 
 # Description
-[mlr](https://mlr-org.github.io/) is an [R](https://cran.r-project.org/) package that integrates almost all machine learning packages in R. [RMVA](http://oproject.org/RMVA){:data-proofer-ignore} is a set of plugins for TMVA based on [ROOTR](http://oproject.org/ROOT+R){:data-proofer-ignore} that allows the use of R in TMVA. The idea is to update the library RMVA to use mlr.
+[mlr](https://mlr-org.github.io/) is an [R](https://cran.r-project.org/) package that integrates almost all machine learning packages in R. [RMVA](http://oproject.org/RMVA){:data-proofer-ignore=""} is a set of plugins for TMVA based on [ROOTR](http://oproject.org/ROOT+R){:data-proofer-ignore=""} that allows the use of R in TMVA. The idea is to update the library RMVA to use mlr.
 
 <!-- oproject is very slow and times out on html-proofer --> 
 
@@ -35,5 +35,5 @@ organization:
 
   * [http://root.cern](http://root.cern)
   * [http://mlr-org.github.io](http://mlr-org.github.io)
-  * [http://oproject.org/RMVA](http://oproject.org/RMVA)
-  * [http://oproject.org/ROOT+R](http://oproject.org/ROOT+R)
+  * [http://oproject.org/RMVA](http://oproject.org/RMVA){:data-proofer-ignore=""}
+  * [http://oproject.org/ROOT+R](http://oproject.org/ROOT+R){:data-proofer-ignore=""}

--- a/organization/team.md
+++ b/organization/team.md
@@ -18,7 +18,7 @@ Currently the activities within the HSF are organized by the *HSF startup team*.
  * Dario Menasce - [INFN](http://www.mi.infn.it)
  * Mark Neubauer - University of Illinois at Urbana-Champaign
  * Elizabeth Sexton-Kennedy - [FNAL](http://www.fnal.gov)
- * Graeme Stewart - [Glasgow](http://www.gla.ac.uk/schools/physics/research/groups/particlephysicsexperiment/)
+ * Graeme Stewart - [CERN](https://cern.ch)
  * Craig Tull - [LBNL](http://www.lbl.gov)
  * Andrea Valassi - [CERN](http://cern.ch)
  * Brett Viren - [BNL](https://www.bnl.gov)


### PR DESCRIPTION
At some point the kramdown engine started to ignore plain URL attributes, which meant that the html-proofer was checking some URLs we know are unreliable/bad (like rucio). To solve this I used an attribute with an empty value, which seems to work ok. So this should reduce the number of false positive errors.

One minor update to the jekyll configuration was to change to "plugins" from "gems" (deprecated).

I also corrected my own affiliation.