### PR TITLE
Fix typos in RAL description

### DIFF
--- a/_gsocorgs/2018/ral.md
+++ b/_gsocorgs/2018/ral.md
@@ -5,9 +5,7 @@ layout: default
 organization: RAL
 logo: logo_RAL.jpg
 description: |
-  STFC Rutherford Appleton Laboratory in Oxfordshire, United Kingdom is home to national facilities including
-  the Diamond synchroton and ISIS neutron spallation source. The Particle Physics Department contributes to
-  experiments including ATLAS, CMS and T2K.
+  STFC Rutherford Appleton Laboratory in Oxfordshire, United Kingdom is home to national facilities including the Diamond synchrotron and ISIS neutron spallation source. The Particle Physics Department contributes to experiments including ATLAS, CMS and T2K.
 ---
 
 {% include gsoc_proposal.ext %}


### PR DESCRIPTION
Fix typos and bad word-wraps.
![screen shot 2018-01-29 at 13 26 13](https://user-images.githubusercontent.com/834238/35512577-247dacb6-04f8-11e8-956a-a6baf7d751a6.png)
