### PR TITLE
Ignore GenToo Package url in htmlproofer checks

### DIFF
--- a/organization/_posts/2016-07-07-startup.md
+++ b/organization/_posts/2016-07-07-startup.md
@@ -61,8 +61,9 @@ layout: default
 -   Pere: what are the next steps? LHCb wants to try it out and have more people 
   in the community to play with it.
 
--   Suggestion from Guilherme: consider [Gentoo Linux Portage package manager](https://wiki.gentoo.org/wiki/Portage) as a means of software 
-    distribution. Packages already available can be seen on Gentoo [package index](https://packages.gentoo.org/categories).
+-   Suggestion from Guilherme: consider [Gentoo Linux Portage package manager](https://wiki.gentoo.org/wiki/Portage) 
+    as a means of software distribution. Packages already available can be seen on Gentoo 
+    [package index](https://packages.gentoo.org/categories){:data-proofer-ignore=""}.
     Benedikt encourages Guilherme to discuss it in the packaging WG: may be the topic for one of the next WG meetings.
 
 ### Licencing


### PR DESCRIPTION
This URL is often timing out in tests despite it is valid, resulting in
test failures not related to changes