### PR TITLE
Run container for proofing as current user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install: /bin/true
  
 script:
-  - docker run --volume $(pwd):/srv/jekyll --interactive --tty graemeastewart/hsf-jekyll /bin/sh -c /srv/jekyll/.travis-scripts/html-proofer
+  - docker run --volume $(pwd):/srv/jekyll --interactive --tty --user $(id -u) graemeastewart/hsf-jekyll /bin/sh -c /srv/jekyll/.travis-scripts/html-proofer
 
 # branch whitelist, only for GitHub Pages
 branches:


### PR DESCRIPTION
This is a better fix for matching the container UID to that of the user who checked out the git repo: use docker's `--user` option to ensure the container has the same identity.
