### PR TITLE
Change docker invocation command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install: /bin/true
  
 script:
-  - docker run --volume $(pwd):/srv/jekyll --interactive --tty --user $(id -u) graemeastewart/hsf-jekyll /bin/sh -c /srv/jekyll/.travis-scripts/html-proofer
+  - docker run --volume $(pwd):/srv/jekyll --interactive --tty --user $(id -u) --env HOME=/tmp graemeastewart/hsf-jekyll /bin/sh -c /srv/jekyll/.travis-scripts/html-proofer
 
 # branch whitelist, only for GitHub Pages
 branches:


### PR DESCRIPTION
To address some issues with using a docker container with an unknown UID
internally (`user=$(id -u)`) it's better to run with an explicit `HOME` set to `/tmp`.
This allows the docker container to run properly for both website preview and
html proofing, without giving spurious warnings.

I have an updated container ready to tag, this change adapts to it correctly.